### PR TITLE
Fix Windows build

### DIFF
--- a/contrib/vstudio/vc10/zlibvc.def
+++ b/contrib/vstudio/vc10/zlibvc.def
@@ -132,7 +132,6 @@ EXPORTS
 
 ; zlib1 v1.2.6 added:
         gzgetc_                                 @161
-        gzflags                                 @162
         inflateResetKeep                        @163
         deflateResetKeep                        @164
 

--- a/contrib/vstudio/vc9/zlibvc.def
+++ b/contrib/vstudio/vc9/zlibvc.def
@@ -132,7 +132,6 @@ EXPORTS
 
 ; zlib1 v1.2.6 added:
         gzgetc_                                 @161
-        gzflags                                 @162
         inflateResetKeep                        @163
         deflateResetKeep                        @164
 


### PR DESCRIPTION
Removed the undefined gzflags export, which causes a build failure.
