### PR TITLE
CMakeLists.txt fixes for linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ endif()
 if(UNIX)
     # On unix-like platforms the library is almost always called libz
    set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,zlib.map")
+   set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/zlib.map")
 elseif(BUILD_SHARED_LIBS AND WIN32)
     # Creates zlib1.dll when building shared library version
     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")


### PR DESCRIPTION
When I tried to add zlib as an external project on linux like so:

```
ExternalProject_add( zlib
    GIT_REPOSITORY git://github.com/madler/zlib.git
    GIT_TAG develop
    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/zlib-install
)
```

I got a couple of errors which I've fixed in this pull request.

``` c
#define ZLIB_VERSION "1.2.7-motley"
```

wasn't getting parsed correctly with the current regex.

Also,

```
-Wl,--version-script,zlib.map
```

wasn't finding zlib.map, which may have to do with it being an "external project".
