### PR TITLE
Restore gzflags symbol for ABI compatibility

### DIFF
--- a/zlib.map
+++ b/zlib.map
@@ -73,6 +73,7 @@ ZLIB_1.2.5.1 {
 
 ZLIB_1.2.5.2 {
     deflateResetKeep;
+    gzflags;
     gzgetc_;
     inflateResetKeep;
 } ZLIB_1.2.5.1;

--- a/zutil.c
+++ b/zutil.c
@@ -321,4 +321,10 @@ void ZLIB_INTERNAL zcfree (opaque, ptr)
 
 #endif /* MY_ZCALLOC */
 
+/* Dummy function returned for ABI compatibility */
+unsigned long ZEXPORT gzflags (void)
+{
+    return 0;
+}
+
 #endif /* !Z_SOLO */


### PR DESCRIPTION
zlib 1.2.7 no longer uses the gzflags symbol but since it was previously
an exported symbol we should really retain it in order to preserve
binary compatibility in case anything linked with it; nothing should
have been doing so but the cost of retaining the symbol is very low so
just do it.
