### PR TITLE
Fixed linker error for static lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,14 @@ endif()
 
 # Explicitly set machine type for VS2010 x64 to fix a linker error when trying
 # to build static libraries using .rc files.
+# Also set it for x86 to prevent a linker warning.
 # For details see: http://public.kitware.com/Bug/view.php?id=11240
-if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set_target_properties(zlibstatic PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+if(MSVC)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set_target_properties(zlibstatic PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x64")
+    else()
+        set_target_properties(zlibstatic PROPERTIES STATIC_LIBRARY_FLAGS "/machine:x86")
+    endif()
 endif()
 
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )


### PR DESCRIPTION
VS2010 x64 has a problem with building static libraries containing an .rc file. The machine type isn't set and the default of x86 is assumed, which obviously won't work. This fix will explicitly set the machine type to x64 to prevent the error.
