### PR TITLE
Linking fails if source path contains spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ endif()
 if(UNIX)
     # On unix-like platforms the library is almost always called libz
    set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/zlib.map")
+   set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
 elseif(BUILD_SHARED_LIBS AND WIN32)
     # Creates zlib1.dll when building shared library version
     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")


### PR DESCRIPTION
To reproduce:

```
$ mkdir -p "/tmp/path with space/build"
$ cp -a zlib /tmp/path\ with\ space/
$ cd /tmp/path\ with\ space/build
$ cmake ../zlib
...
 -- Build files have been written to: /tmp/path with space/build
$ make 
Scanning dependencies of target zlib
[  3%] Building C object CMakeFiles/zlib.dir/adler32.o
[  6%] Building C object CMakeFiles/zlib.dir/compress.o
[  9%] Building C object CMakeFiles/zlib.dir/crc32.o
[ 12%] Building C object CMakeFiles/zlib.dir/deflate.o
[ 15%] Building C object CMakeFiles/zlib.dir/gzclose.o
[ 18%] Building C object CMakeFiles/zlib.dir/gzlib.o
[ 21%] Building C object CMakeFiles/zlib.dir/gzread.o
[ 25%] Building C object CMakeFiles/zlib.dir/gzwrite.o
[ 28%] Building C object CMakeFiles/zlib.dir/inflate.o
[ 31%] Building C object CMakeFiles/zlib.dir/infback.o
[ 34%] Building C object CMakeFiles/zlib.dir/inftrees.o
[ 37%] Building C object CMakeFiles/zlib.dir/inffast.o
[ 40%] Building C object CMakeFiles/zlib.dir/trees.o
[ 43%] Building C object CMakeFiles/zlib.dir/uncompr.o
[ 46%] Building C object CMakeFiles/zlib.dir/zutil.o
    Linking C shared library libz.dylib
i686-apple-darwin11-llvm-gcc-4.2: with: No such file or directory
i686-apple-darwin11-llvm-gcc-4.2: space/zlib/zlib.map: No such file or directory
make[2]: *** [libz.1.2.7.dylib] Error 1
make[1]: *** [CMakeFiles/zlib.dir/all] Error 2
make: *** [all] Error 2
```

This commit explicitly quotes the path in `-Wl,--version-script,<path>`.
