### PR TITLE
Mac OS X linker does not support --version-script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,9 @@ endif()
 if(UNIX)
     # On unix-like platforms the library is almost always called libz
    set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/zlib.map")
+   if(NOT APPLE)
+     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/zlib.map")
+   endif()
 elseif(BUILD_SHARED_LIBS AND WIN32)
     # Creates zlib1.dll when building shared library version
     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")


### PR DESCRIPTION
Mac OS X's linker is derived from LLVM, not GNU binutils, and it does not support `--version-script`.

This  commit disables that option for `APPLE`. There are some possible problems with this:
- It might be too broad, since I understand CMake sets `APPLE` for all versions of Mac OS. I have no idea what toolchains exist on Mac OS 9 or earlier, so I have no way of knowing if this is correct.
- Without `--version-script`, there's nothing to restrict which symbols are visible in the resulting libraries.

I don't know if either of these are important. That said, I _do_ know that Mac OS X is broken with both the current release and the current master:

```
Linking C shared library libz.dylib
ld: unknown option: --version-script
collect2: ld returned 1 exit status
make[2]: *** [libz.1.2.7.dylib] Error 1
make[1]: *** [CMakeFiles/zlib.dir/all] Error 2
```

It builds with this change.
