### PR TITLE
Fix crc_table pointer in minizip.

### DIFF
--- a/contrib/minizip/crypt.h
+++ b/contrib/minizip/crypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys, const z_crc_t* pcrc_32_tab)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -45,7 +45,7 @@ static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
 /***********************************************************************
  * Update the encryption keys with the next byte of plain text
  */
-static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+static int update_keys(unsigned long* pkeys,const z_crc_t* pcrc_32_tab,int c)
 {
     (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
     (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
@@ -62,7 +62,7 @@ static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int
  * Initialize the encryption keys and the random header according to
  * the given password.
  */
-static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+static void init_keys(const char* passwd,unsigned long* pkeys,const z_crc_t* pcrc_32_tab)
 {
     *(pkeys+0) = 305419896L;
     *(pkeys+1) = 591751049L;
@@ -91,7 +91,7 @@ static int crypthead(const char* passwd,      /* password string */
                      unsigned char* buf,      /* where to write header */
                      int bufSize,
                      unsigned long* pkeys,
-                     const unsigned long* pcrc_32_tab,
+                     const z_crc_t* pcrc_32_tab,
                      unsigned long crcForCrypting)
 {
     int n;                       /* index in random header */

--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -188,7 +188,7 @@ typedef struct
 
 #    ifndef NOUNCRYPT
     unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    const z_crc_t* pcrc_32_tab;
 #    endif
 } unz64_s;
 

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -157,7 +157,7 @@ typedef struct
     ZPOS64_T totalUncompressedData;
 #ifndef NOCRYPT
     unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    const z_crc_t* pcrc_32_tab;
     int crypt_header_size;
 #endif
 } curfile64_info;


### PR DESCRIPTION
Looks like the changes in 6c9bd474aa08312ef2e2e9655a80e18db24a1680 made the minizip partially non-usable with re-enabled crypto support. 
The encrypted zip files created by the minizip are impossible to extract with other programs, and the minizip can't extract encrypted files created by other programs or previous versions.

The affected systems are the LP64 systems (64-bit Unix variants).
64 bit windows systems are not affected.
