### PR TITLE
configure script fails to detect clang on OS X.

### DIFF
--- a/configure
+++ b/configure
@@ -159,6 +159,7 @@ case "$cc" in
 esac
 case `$cc -v 2>&1` in
   *gcc*) gcc=1 ;;
+  *clang*) gcc=1 ;;
 esac
 
 show $cc -c $test.c


### PR DESCRIPTION
On OS X, when "cc" points to clang, configure script fails to detect it and
builds an incorrect shared library.
