### PR TITLE
Adjustment to iowin32 of minizip to allow explicitly ignoring the WinRT API

### DIFF
--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -32,6 +32,10 @@
 #endif
 #endif
 
+#ifndef IOWIN32_USING_WINRT_API
+#define IOWIN32_USING_WINRT_API 0
+#endif
+
 voidpf  ZCALLBACK win32_open_file_func  OF((voidpf opaque, const char* filename, int mode));
 uLong   ZCALLBACK win32_read_file_func  OF((voidpf opaque, voidpf stream, void* buf, uLong size));
 uLong   ZCALLBACK win32_write_file_func OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
@@ -100,7 +104,7 @@ voidpf ZCALLBACK win32_open64_file_func (voidpf opaque,const void* filename,int 
 
     win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-#ifdef IOWIN32_USING_WINRT_API
+#if IOWIN32_USING_WINRT_API > 0
 #ifdef UNICODE
     if ((filename!=NULL) && (dwDesiredAccess != 0))
         hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
@@ -129,7 +133,7 @@ voidpf ZCALLBACK win32_open64_file_funcA (voidpf opaque,const void* filename,int
 
     win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-#ifdef IOWIN32_USING_WINRT_API
+#if IOWIN32_USING_WINRT_API > 0
     if ((filename!=NULL) && (dwDesiredAccess != 0))
     {
         WCHAR filenameW[FILENAME_MAX + 0x200 + 1];
@@ -153,7 +157,7 @@ voidpf ZCALLBACK win32_open64_file_funcW (voidpf opaque,const void* filename,int
 
     win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-#ifdef IOWIN32_USING_WINRT_API
+#if IOWIN32_USING_WINRT_API > 0
     if ((filename!=NULL) && (dwDesiredAccess != 0))
         hFile = CreateFile2((LPCWSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition,NULL);
 #else
@@ -173,7 +177,7 @@ voidpf ZCALLBACK win32_open_file_func (voidpf opaque,const char* filename,int mo
 
     win32_translate_open_mode(mode,&dwDesiredAccess,&dwCreationDisposition,&dwShareMode,&dwFlagsAndAttributes);
 
-#ifdef IOWIN32_USING_WINRT_API
+#if IOWIN32_USING_WINRT_API > 0
 #ifdef UNICODE
     if ((filename!=NULL) && (dwDesiredAccess != 0))
         hFile = CreateFile2((LPCTSTR)filename, dwDesiredAccess, dwShareMode, dwCreationDisposition, NULL);
@@ -239,7 +243,7 @@ uLong ZCALLBACK win32_write_file_func (voidpf opaque,voidpf stream,const void* b
 
 static BOOL MySetFilePointerEx(HANDLE hFile, LARGE_INTEGER pos, LARGE_INTEGER *newPos,  DWORD dwMoveMethod)
 {
-#ifdef IOWIN32_USING_WINRT_API
+#if IOWIN32_USING_WINRT_API > 0
     return SetFilePointerEx(hFile, pos, newPos, dwMoveMethod);
 #else
     LONG lHigh = pos.HighPart;


### PR DESCRIPTION
Previously if the WinRT API was available at all on the comipiling machine, it would be used during build regardless of any defines passed in at build-time.  This change will enable one to disable the use of this API by passing the following define:

`IOWIN32_USING_WINRT_API=0`
