### PR TITLE
Fix the output names of libraries in Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,13 @@ if(UNIX)
      set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
    endif()
 elseif(BUILD_SHARED_LIBS AND WIN32)
+    if (MINGW)
+        set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME z)
+        set_target_properties(zlib PROPERTIES ARCHIVE_OUTPUT_NAME z)
+    endif ()
+
     # Creates zlib1.dll when building shared library version
+    set_target_properties(zlib PROPERTIES PREFIX "")
     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
 endif()
 


### PR DESCRIPTION
- Set shared lib to zlib1.dll
- Set implib to libz.dll.a in MinGW
- Set static lib to libz.a in MinGW
