### PR TITLE
Fix cmake build for MSVC with AMD64 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ if(MSVC)
 			contrib/masmx64/gvmat64.asm
 			contrib/masmx64/inffasx64.asm
 		)
+        set(ZLIB_SRCS ${ZLIB_SRCS} contrib/masmx64/inffas8664.c)
     endif()
 
 	if(ZLIB_ASMS)


### PR DESCRIPTION
inffas8664.c must be added to project with gvmat64.asm and inffasx64.asm
