### PR TITLE
Clib support.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "repo": "georgy7/zlib",
   "description": "A general purpose data compression library.",
 
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "description": "A general purpose data compression library.",
+
+  "keywords": [
+    "zip", "gzip", "zlib", "deflate", "compression"
+  ],
+
+  "name": "zlib",
+  
+  "license": "zlib License",
+  
+  "src": [
+    "crc32.h",
+    "deflate.h",
+    "gzguts.h",
+    "inffast.h",
+    "inffixed.h",
+    "inflate.h",
+    "inftrees.h",
+    "trees.h",
+    "zconf.h",
+    "zlib.h",
+    "zutil.h",
+    "adler32.c",
+    "compress.c",
+    "crc32.c",
+    "deflate.c",
+    "gzclose.c",
+    "gzlib.c",
+    "gzread.c",
+    "gzwrite.c",
+    "infback.c",
+    "inffast.c",
+    "inflate.c",
+    "inftrees.c",
+    "trees.c",
+    "uncompr.c",
+    "zutil.c"
+  ],
+  
+  "version": "1.2.8"
+}


### PR DESCRIPTION
[Clib is a package manager for the C programming language.](https://github.com/clibs/clib)
It can download dependencies right from github, but only if these repositories have a package.json file. I made a fork with this file, but, I don't know, maybe it would be better if main zlib repository will be used for this purpose.
