### PR TITLE
Windows pkgconfig fix

### DIFF
--- a/win32/Makefile.gcc
+++ b/win32/Makefile.gcc
@@ -141,10 +141,10 @@ install: zlib.h zconf.h $(STATICLIB) $(IMPLIB)
 	-$(INSTALL) $(STATICLIB) '$(DESTDIR)$(LIBRARY_PATH)'
 	sed \
 		-e 's|@prefix@|${prefix}|g' \
-		-e 's|@exec_prefix@|${exec_prefix}|g' \
-		-e 's|@libdir@|$(LIBRARY_PATH)|g' \
-		-e 's|@sharedlibdir@|$(LIBRARY_PATH)|g' \
-		-e 's|@includedir@|$(INCLUDE_PATH)|g' \
+		-e 's|@exec_prefix@|$${prefix}|g' \
+		-e 's|@libdir@|$${exec_prefix}$(LIBRARY_PATH)|g' \
+		-e 's|@sharedlibdir@|$${exec_prefix}$(LIBRARY_PATH)|g' \
+		-e 's|@includedir@|$${prefix}$(INCLUDE_PATH)|g' \
 		-e 's|@VERSION@|'`sed -n -e '/VERSION "/s/.*"\(.*\)".*/\1/p' zlib.h`'|g' \
 		zlib.pc.in > '$(DESTDIR)$(LIBRARY_PATH)'/pkgconfig/zlib.pc
 


### PR DESCRIPTION
This corrects the zlib.pc file for the MinGW build so that it correctly references the library and include folders.

Before this fix `zlib.pc`:

```
prefix=/the/installation/path
exec_prefix=/the/installation/path
libdir=/path/specified/as/LIBRARY_PATH
sharedlibdir=/path/specified/as/LIBRARY_PATH
includedir=/path/specified/as/INCLUDE_PATH
```

After the fix `zlib.pc`:

```
prefix=/the/installation/path
exec_prefix=${prefix}
libdir=${prefix}/path/specified/as/LIBRARY_PATH
sharedlibdir=${prefix}/path/specified/as/LIBRARY_PATH
includedir=${prefix}/path/specified/as/INCLUDE_PATH
```

This allows `pkgconfig` to correctly find the files.
