### PR TITLE
Close files on error

### DIFF
--- a/contrib/minizip/mztools.c
+++ b/contrib/minizip/mztools.c
@@ -285,6 +285,10 @@ uLong* bytesRecovered;
       }
     }
   } else {
+    if (fpZip)   fclose(fpZip);
+    if (fpOut)   fclose(fpOut);
+    if (fpOutCD) fclose(fpOutCD);
+
     err = Z_STREAM_ERROR;
   }
   return err;


### PR DESCRIPTION
File handles might not have been closed if opening one file did fail. This patch ensures all open file handles are closed. Reported by Jeremy Friesner jfriesne@gmail.com
