### PR TITLE
Fix -Wshift-negative-value warning with clang 3.7

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1504,7 +1504,7 @@ z_streamp strm;
 {
     struct inflate_state FAR *state;
 
-    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;
+    if (strm == Z_NULL || strm->state == Z_NULL) return (unsigned)-1L << 16;
     state = (struct inflate_state FAR *)strm->state;
     return ((long)(state->back) << 16) +
         (state->mode == COPY ? state->length :


### PR DESCRIPTION
This fixes issue #111.