### PR TITLE
Define WIN32_LEAN_AND_MEAN

### DIFF
--- a/contrib/minizip/iowin32.h
+++ b/contrib/minizip/iowin32.h
@@ -11,8 +11,10 @@
 
 */
 
+#if !defined(WIN32_LEAN_AND_MEAN)
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
-
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
This excludes Win APIs such as Cryptography, DDE, RPC, Shell, and Windows Sockets and thus speeds up compilation.