### PR TITLE
Fix CMakeLists.txt for windows compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,10 @@ elseif(BUILD_SHARED_LIBS AND WIN32)
     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
 endif()
 
+if(WIN32)
+    add_definitions(-DZLIB_WINAPI)
+endif(WIN32)
+
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
     install(TARGETS zlib zlibstatic
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"


### PR DESCRIPTION
This fix should allow anybody to use zlib on windows with cmake.
