### PR TITLE
fix MinGW seeking bug + add MSVC 6 projects

### DIFF
--- a/contrib/vstudio/vc6/README.txt
+++ b/contrib/vstudio/vc6/README.txt
@@ -1,0 +1,73 @@
+Microsoft Developer Studio Project Files, Format Version 6.00 for zlib.
+
+Copyright (C) 2000-2004 Simon-Pierre Cadieux.
+Copyright (C) 2004 Cosmin Truta.
+For conditions of distribution and use, see copyright notice in zlib.h.
+
+
+This project builds the zlib binaries as follows:
+
+* Win32_DLL_Release\zlib1.dll               DLL build
+* Win32_DLL_Debug\zlib1d.dll                DLL build (debug version)
+* Win32_LIB_Release\zlib.lib                static build
+* Win32_LIB_Debug\zlibd.lib                 static build (debug version)
+* Win32_WINAPI_DLL_Release\zlibwapi.dll     DLL build, using STDCALL calling convention
+
+
+For more information regarding the DLL builds, please see the DLL FAQ
+in ..\..\..\win32\DLL_FAQ.txt.
+
+
+To build and test:
+
+1) On the main menu, select "File | Open Workspace".
+   Open "zlib.dsw".
+
+2) Select "Build | Set Active Configuration".
+   Choose the configuration you wish to build.
+
+3) Select "Build | Clean".
+
+4) Select "Build | Build ... (F7)".  Ignore warning messages about
+   not being able to find certain include files (e.g. alloc.h).
+
+5) If you built one of the sample programs (example or minigzip),
+   select "Build | Execute ... (Ctrl+F5)".
+
+
+To use:
+
+1) Select "Project | Settings (Alt+F7)".
+   Make note of the configuration names used in your project.
+   Usually, these names are "Win32 Release" and "Win32 Debug".
+
+2) In the Workspace window, select the "FileView" tab.
+   Right-click on the root item "Workspace '...'".
+   Select "Insert Project into Workspace".
+   Switch on the checkbox "Dependency of:", and select the name
+   of your project.  Open "zlib.dsp".
+
+3) Select "Build | Configurations".
+   For each configuration of your project:
+   3.1) Choose the zlib configuration you wish to use.
+   3.2) Click on "Add".
+   3.3) Set the new zlib configuration name to the name used by
+        the configuration from the current iteration.
+
+4) Select "Build | Set Active Configuration".
+   Choose the configuration you wish to build.
+
+5) Select "Build | Build ... (F7)".
+
+6) If you built an executable program, select
+   "Build | Execute ... (Ctrl+F5)".
+
+
+Note:
+
+The ASM-enabled builds that were present in the original project
+were removed, because I can't maintain them.
+DLL builds are linked against MSVCRT.DLL and use /nodefaultlib
+to minimize the size of the resulting DLL.
+LIB builds are compiled in "Multithreaded DLL" mode and have to
+be linked against MSVCRT.DLL.

--- a/contrib/vstudio/vc6/example.dsp
+++ b/contrib/vstudio/vc6/example.dsp
@@ -1,0 +1,166 @@
+# Microsoft Developer Studio Project File - Name="example" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Console Application" 0x0103
+
+CFG=example - Win32 LIB Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE
+!MESSAGE NMAKE /f "example.mak".
+!MESSAGE
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE
+!MESSAGE NMAKE /f "example.mak" CFG="example - Win32 LIB Debug"
+!MESSAGE
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "example - Win32 DLL Release" (based on  "Win32 (x86) Console Application")
+!MESSAGE "example - Win32 DLL Debug" (based on  "Win32 (x86) Console Application")
+!MESSAGE "example - Win32 LIB Release" (based on  "Win32 (x86) Console Application")
+!MESSAGE "example - Win32 LIB Debug" (based on  "Win32 (x86) Console Application")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "example - Win32 DLL Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "example___Win32_DLL_Release"
+# PROP BASE Intermediate_Dir "example___Win32_DLL_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_DLL_Release"
+# PROP Intermediate_Dir "Win32_DLL_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MD /W3 /O2 /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 /nologo /subsystem:console /machine:I386
+
+!ELSEIF  "$(CFG)" == "example - Win32 DLL Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "example___Win32_DLL_Debug"
+# PROP BASE Intermediate_Dir "example___Win32_DLL_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_DLL_Debug"
+# PROP Intermediate_Dir "Win32_DLL_Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+
+!ELSEIF  "$(CFG)" == "example - Win32 LIB Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "example___Win32_LIB_Release"
+# PROP BASE Intermediate_Dir "example___Win32_LIB_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_LIB_Release"
+# PROP Intermediate_Dir "Win32_LIB_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MD /W3 /O2 /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 /nologo /subsystem:console /machine:I386
+
+!ELSEIF  "$(CFG)" == "example - Win32 LIB Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "example___Win32_LIB_Debug"
+# PROP BASE Intermediate_Dir "example___Win32_LIB_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_LIB_Debug"
+# PROP Intermediate_Dir "Win32_LIB_Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+
+!ENDIF 
+
+# Begin Target
+
+# Name "example - Win32 DLL Release"
+# Name "example - Win32 DLL Debug"
+# Name "example - Win32 LIB Release"
+# Name "example - Win32 LIB Debug"
+# Begin Group "Source Files"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=..\..\..\test\example.c
+# End Source File
+# End Group
+# Begin Group "Header Files"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl"
+# Begin Source File
+
+SOURCE=..\..\..\zconf.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zlib.h
+# End Source File
+# End Group
+# End Target
+# End Project

--- a/contrib/vstudio/vc6/minigzip.dsp
+++ b/contrib/vstudio/vc6/minigzip.dsp
@@ -1,0 +1,166 @@
+# Microsoft Developer Studio Project File - Name="minigzip" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Console Application" 0x0103
+
+CFG=minigzip - Win32 LIB Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE
+!MESSAGE NMAKE /f "minigzip.mak".
+!MESSAGE
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE
+!MESSAGE NMAKE /f "minigzip.mak" CFG="minigzip - Win32 LIB Debug"
+!MESSAGE
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "minigzip - Win32 DLL Release" (based on  "Win32 (x86) Console Application")
+!MESSAGE "minigzip - Win32 DLL Debug" (based on  "Win32 (x86) Console Application")
+!MESSAGE "minigzip - Win32 LIB Release" (based on  "Win32 (x86) Console Application")
+!MESSAGE "minigzip - Win32 LIB Debug" (based on  "Win32 (x86) Console Application")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+CPP=cl.exe
+RSC=rc.exe
+
+!IF  "$(CFG)" == "minigzip - Win32 DLL Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "minigzip___Win32_DLL_Release"
+# PROP BASE Intermediate_Dir "minigzip___Win32_DLL_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_DLL_Release"
+# PROP Intermediate_Dir "Win32_DLL_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MD /W3 /O2 /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 /nologo /subsystem:console /machine:I386
+
+!ELSEIF  "$(CFG)" == "minigzip - Win32 DLL Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "minigzip___Win32_DLL_Debug"
+# PROP BASE Intermediate_Dir "minigzip___Win32_DLL_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_DLL_Debug"
+# PROP Intermediate_Dir "Win32_DLL_Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+
+!ELSEIF  "$(CFG)" == "minigzip - Win32 LIB Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "minigzip___Win32_LIB_Release"
+# PROP BASE Intermediate_Dir "minigzip___Win32_LIB_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_LIB_Release"
+# PROP Intermediate_Dir "Win32_LIB_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MD /W3 /O2 /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /machine:I386
+# ADD LINK32 /nologo /subsystem:console /machine:I386
+
+!ELSEIF  "$(CFG)" == "minigzip - Win32 LIB Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "minigzip___Win32_LIB_Debug"
+# PROP BASE Intermediate_Dir "minigzip___Win32_LIB_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_LIB_Debug"
+# PROP Intermediate_Dir "Win32_LIB_Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /I "..\..\.." /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 /nologo /subsystem:console /debug /machine:I386 /pdbtype:sept
+
+!ENDIF 
+
+# Begin Target
+
+# Name "minigzip - Win32 DLL Release"
+# Name "minigzip - Win32 DLL Debug"
+# Name "minigzip - Win32 LIB Release"
+# Name "minigzip - Win32 LIB Debug"
+# Begin Group "Source Files"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=..\..\..\test\minigzip.c
+# End Source File
+# End Group
+# Begin Group "Header Files"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl"
+# Begin Source File
+
+SOURCE=..\..\..\zconf.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zlib.h
+# End Source File
+# End Group
+# End Target
+# End Project

--- a/contrib/vstudio/vc6/zlib.dsp
+++ b/contrib/vstudio/vc6/zlib.dsp
@@ -1,0 +1,331 @@
+# Microsoft Developer Studio Project File - Name="zlib" - Package Owner=<4>
+# Microsoft Developer Studio Generated Build File, Format Version 6.00
+# ** DO NOT EDIT **
+
+# TARGTYPE "Win32 (x86) Dynamic-Link Library" 0x0102
+# TARGTYPE "Win32 (x86) Static Library" 0x0104
+
+CFG=zlib - Win32 LIB Debug
+!MESSAGE This is not a valid makefile. To build this project using NMAKE,
+!MESSAGE use the Export Makefile command and run
+!MESSAGE
+!MESSAGE NMAKE /f "zlib.mak".
+!MESSAGE
+!MESSAGE You can specify a configuration when running NMAKE
+!MESSAGE by defining the macro CFG on the command line. For example:
+!MESSAGE
+!MESSAGE NMAKE /f "zlib.mak" CFG="zlib - Win32 LIB Debug"
+!MESSAGE
+!MESSAGE Possible choices for configuration are:
+!MESSAGE 
+!MESSAGE "zlib - Win32 DLL Release" (based on  "Win32 (x86) Dynamic-Link Library")
+!MESSAGE "zlib - Win32 DLL Debug" (based on  "Win32 (x86) Dynamic-Link Library")
+!MESSAGE "zlib - Win32 LIB Release" (based on  "Win32 (x86) Static Library")
+!MESSAGE "zlib - Win32 LIB Debug" (based on  "Win32 (x86) Static Library")
+!MESSAGE "zlib - Win32 WINAPI DLL Release" (based on  "Win32 (x86) Dynamic-Link Library")
+!MESSAGE 
+
+# Begin Project
+# PROP AllowPerConfigDependencies 0
+# PROP Scc_ProjName ""
+# PROP Scc_LocalPath ""
+
+!IF  "$(CFG)" == "zlib - Win32 DLL Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "zlib___Win32_DLL_Release"
+# PROP BASE Intermediate_Dir "zlib___Win32_DLL_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_DLL_Release"
+# PROP Intermediate_Dir "Win32_DLL_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+CPP=cl.exe
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX /Yc /Yu
+# ADD CPP /nologo /MD /W3 /O2 /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX /Yc /Yu
+MTL=midl.exe
+# ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
+# ADD MTL /nologo /D "NDEBUG" /mktyplib203 /win32
+RSC=rc.exe
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /dll /machine:I386
+# ADD LINK32 msvcrt.lib oldnames.lib kernel32.lib /nologo /dll /machine:I386 /nodefaultlib /out:"Win32_DLL_Release\zlib1.dll"
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 DLL Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "zlib___Win32_DLL_Debug"
+# PROP BASE Intermediate_Dir "zlib___Win32_DLL_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_DLL_Debug"
+# PROP Intermediate_Dir "Win32_DLL_Debug"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+CPP=cl.exe
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX /Yc /Yu
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX /Yc /Yu
+MTL=midl.exe
+# ADD BASE MTL /nologo /D "_DEBUG" /mktyplib203 /win32
+# ADD MTL /nologo /D "_DEBUG" /mktyplib203 /win32
+RSC=rc.exe
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /dll /debug /machine:I386 /pdbtype:sept
+# ADD LINK32 msvcrtd.lib oldnames.lib kernel32.lib /nologo /dll /debug /machine:I386 /nodefaultlib /out:"Win32_DLL_Debug\zlib1d.dll" /pdbtype:sept
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 LIB Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "zlib___Win32_LIB_Release"
+# PROP BASE Intermediate_Dir "zlib___Win32_LIB_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_LIB_Release"
+# PROP Intermediate_Dir "Win32_LIB_Release"
+# PROP Target_Dir ""
+CPP=cl.exe
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX /Yc /Yu
+# ADD CPP /nologo /MD /W3 /O2 /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /FD /c
+# SUBTRACT CPP /YX /Yc /Yu
+RSC=rc.exe
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 LIB Debug"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 1
+# PROP BASE Output_Dir "zlib___Win32_LIB_Debug"
+# PROP BASE Intermediate_Dir "zlib___Win32_LIB_Debug"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 1
+# PROP Output_Dir "Win32_LIB_Debug"
+# PROP Intermediate_Dir "Win32_LIB_Debug"
+# PROP Target_Dir ""
+CPP=cl.exe
+# ADD BASE CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_DEBUG" /FD /GZ /c
+# SUBTRACT BASE CPP /YX /Yc /Yu
+# ADD CPP /nologo /MDd /W3 /Gm /ZI /Od /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "_DEBUG" /FR /FD /GZ /c
+# SUBTRACT CPP /YX /Yc /Yu
+RSC=rc.exe
+# ADD BASE RSC /l 0x409 /d "_DEBUG"
+# ADD RSC /l 0x409 /d "_DEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LIB32=link.exe -lib
+# ADD BASE LIB32 /nologo
+# ADD LIB32 /nologo /out:"Win32_LIB_Debug\zlibd.lib"
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 WINAPI DLL Release"
+
+# PROP BASE Use_MFC 0
+# PROP BASE Use_Debug_Libraries 0
+# PROP BASE Output_Dir "zlib___Win32_WINAPI_DLL_Release"
+# PROP BASE Intermediate_Dir "zlib___Win32_WINAPI_DLL_Release"
+# PROP BASE Target_Dir ""
+# PROP Use_MFC 0
+# PROP Use_Debug_Libraries 0
+# PROP Output_Dir "Win32_WINAPI_DLL_Release"
+# PROP Intermediate_Dir "Win32_WINAPI_DLL_Release"
+# PROP Ignore_Export_Lib 0
+# PROP Target_Dir ""
+CPP=cl.exe
+# ADD BASE CPP /nologo /MD /W3 /O2 /D "WIN32" /D "NDEBUG" /FD /c
+# SUBTRACT BASE CPP /YX /Yc /Yu
+# ADD CPP /nologo /MD /W3 /O2 /D "WIN32" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_NONSTDC_NO_DEPRECATE" /D "NDEBUG" /D "ZLIB_WINAPI" /FD /c
+# SUBTRACT CPP /YX /Yc /Yu
+MTL=midl.exe
+# ADD BASE MTL /nologo /D "NDEBUG" /mktyplib203 /win32
+# ADD MTL /nologo /D "NDEBUG" /mktyplib203 /win32
+RSC=rc.exe
+# ADD BASE RSC /l 0x409 /d "NDEBUG"
+# ADD RSC /l 0x409 /d "NDEBUG"
+BSC32=bscmake.exe
+# ADD BASE BSC32 /nologo
+# ADD BSC32 /nologo
+LINK32=link.exe
+# ADD BASE LINK32 kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib shell32.lib ole32.lib oleaut32.lib uuid.lib odbc32.lib odbccp32.lib /nologo /dll /machine:I386
+# ADD LINK32 msvcrt.lib oldnames.lib kernel32.lib /nologo /dll /machine:I386 /nodefaultlib /out:"Win32_WINAPI_DLL_Release\zlibwapi.dll"
+
+!ENDIF 
+
+# Begin Target
+
+# Name "zlib - Win32 DLL Release"
+# Name "zlib - Win32 DLL Debug"
+# Name "zlib - Win32 LIB Release"
+# Name "zlib - Win32 LIB Debug"
+# Name "zlib - Win32 WINAPI DLL Release"
+# Begin Group "Source Files"
+
+# PROP Default_Filter "cpp;c;cxx;rc;def;r;odl;idl;hpj;bat"
+# Begin Source File
+
+SOURCE=..\..\..\adler32.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\compress.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\crc32.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\deflate.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\gzclose.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\gzlib.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\gzread.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\gzwrite.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\infback.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inffast.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inflate.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inftrees.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\trees.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\uncompr.c
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\win32\zlib.def
+
+!IF  "$(CFG)" == "zlib - Win32 DLL Release"
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 DLL Debug"
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 LIB Release"
+
+# PROP Exclude_From_Build 1
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 LIB Debug"
+
+# PROP Exclude_From_Build 1
+
+!ELSEIF  "$(CFG)" == "zlib - Win32 WINAPI DLL Release"
+
+!ENDIF 
+
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zutil.c
+# End Source File
+# End Group
+# Begin Group "Header Files"
+
+# PROP Default_Filter "h;hpp;hxx;hm;inl"
+# Begin Source File
+
+SOURCE=..\..\..\crc32.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\deflate.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inffast.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inffixed.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inflate.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\inftrees.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\trees.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zconf.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zlib.h
+# End Source File
+# Begin Source File
+
+SOURCE=..\..\..\zutil.h
+# End Source File
+# End Group
+# Begin Group "Resource Files"
+
+# PROP Default_Filter "ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe"
+# Begin Source File
+
+SOURCE=..\..\..\win32\zlib1.rc
+# End Source File
+# End Group
+# Begin Source File
+
+SOURCE=..\readme.txt
+# End Source File
+# End Target
+# End Project

--- a/contrib/vstudio/vc6/zlib.dsw
+++ b/contrib/vstudio/vc6/zlib.dsw
@@ -1,0 +1,59 @@
+Microsoft Developer Studio Workspace File, Format Version 6.00
+# WARNING: DO NOT EDIT OR DELETE THIS WORKSPACE FILE!
+
+###############################################################################
+
+Project: "example"=.\example.dsp - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+    Begin Project Dependency
+    Project_Dep_Name zlib
+    End Project Dependency
+}}}
+
+###############################################################################
+
+Project: "minigzip"=.\minigzip.dsp - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+    Begin Project Dependency
+    Project_Dep_Name zlib
+    End Project Dependency
+}}}
+
+###############################################################################
+
+Project: "zlib"=.\zlib.dsp - Package Owner=<4>
+
+Package=<5>
+{{{
+}}}
+
+Package=<4>
+{{{
+}}}
+
+###############################################################################
+
+Global:
+
+Package=<5>
+{{{
+}}}
+
+Package=<3>
+{{{
+}}}
+
+###############################################################################
+

--- a/gzlib.c
+++ b/gzlib.c
@@ -5,7 +5,7 @@
 
 #include "gzguts.h"
 
-#if defined(_WIN32) && !defined(__BORLANDC__)
+#if defined(_WIN32) && !defined(__BORLANDC__) && !defined(__MINGW32__)
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
@@ -393,7 +393,10 @@ z_off64_t ZEXPORT gzseek64(file, offset, whence)
     /* if within raw area while reading, just go there */
     if (state->mode == GZ_READ && state->how == COPY &&
             state->x.pos + offset >= 0) {
-        ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
+        if (whence == SEEK_SET)
+            ret = LSEEK(state->fd, state->x.pos + offset, SEEK_SET);
+        else
+            ret = LSEEK(state->fd, offset - state->x.have, SEEK_CUR);
         if (ret == -1)
             return -1;
         state->x.have = 0;

--- a/test/example.c
+++ b/test/example.c
@@ -5,7 +5,7 @@
 
 /* @(#) $Id$ */
 
-#include "zlib.h"
+#include <zlib.h>
 #include <stdio.h>
 
 #ifdef STDC

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
-#include "zlib.h"
+#include <zlib.h>
 
 /* get definition of internal structure so we can mess with it (see pull()),
    and so we can call inflate_trees() (see cover5()) */

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -15,7 +15,7 @@
 
 /* @(#) $Id$ */
 
-#include "zlib.h"
+#include <zlib.h>
 #include <stdio.h>
 
 #ifdef STDC


### PR DESCRIPTION
I fixed the MinGW seeking bug #95 by preventing it from using _lseeki64, which seems broken in some MinGW versions.
I also improved the seeking code slightly to use SEEK_SET for seeking to absolute file offsets.

The header fix for the example programs is required for them to build with MSVC6. (and more correct anyway, because they aren't in the same folder as zlib.h anymore)

The project files for Visual C++ 6 are based on the old project that was present in zlib 1.2.5. I removed the ASM build targets and fixed the other ones.
