### PR TITLE
.gitignore Makefile and zconf.h

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 /zlib.pc
 
 .DS_Store
+
+Makefile
+zconf.h

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 
 Makefile
 zconf.h
+configure.log


### PR DESCRIPTION
Both of these are generated at configure time and don't need to be in the git repository.
