### PR TITLE
fixed compilation in MSVC 2013 and enable IOWIN32_USING_WINRT_API only on non-desktop Windows platforms

### DIFF
--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -27,8 +27,9 @@
 
 
 // see Include/shared/winapifamily.h in the Windows Kit
-#if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
-#if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
+#if defined(WINAPI_FAMILY) && (!(defined(IOWIN32_USING_WINRT_API)))
+#include <winapifamily.h>
+#if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 #define IOWIN32_USING_WINRT_API 1
 #endif
 #endif


### PR DESCRIPTION
On my computer I have WINAPI_FAMILY_ONE_PARTITION undefined and WINAPI_FAMILY_PARTITION defined.

I have MSVC 2013 update 5, windows 8.1, SDK 8.1

I modified the code to have few changes:

- [ ] check for WINAPI_FAMILY defined to decide current SDK knows about different Microsoft platforms.
- [ ] include <winapifamily.h> when it is available. It guarantees WINAPI_PARTITION_DESKTOP is really defined here.
- [ ] define IOWIN32_USING_WINRT_API only on non-desktop platforms. So we support very old API on desktop and support as much Windows version as possible. In other case we would support Windows 8 only.
