### PR TITLE
Include zconf.h in example binary in order to fix CMake's add_subdirectory()

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -5,6 +5,7 @@
 
 /* @(#) $Id$ */
 
+#include "zconf.h"
 #include "zlib.h"
 #include <stdio.h>
 


### PR DESCRIPTION
Alright so this probably isn't the _best_ way to fix this.

When including `zlib` from a parent project using CMake's `add_subdirectory()` function, the build fails - but only in `test/example.c`.

It whines about `z_const` and not being able to find it. Turns out, for some reason, `zconf.h` isn't being included. This PR fixes that.

The other option is to have someone more familiar with the library figure out why this is happening in the first place. If I'm understanding the header hierarchy correctly, `zconf.h` should be included with `zlib.h` - but that doesn't seem to be the case with `test/example.c`.

Alternatively, we could also add an option to disable building the examples.

I'm at least submitting the PR so if someone else runs across the issue prior to it being fixed they'll know what to do.
