### PR TITLE
Major speed up to _tr_stored_block().

### DIFF
--- a/deflate.h
+++ b/deflate.h
@@ -276,6 +276,7 @@ typedef struct internal_state {
  * IN assertion: there is enough room in pending_buf.
  */
 #define put_byte(s, c) {s->pending_buf[s->pending++] = (c);}
+#define put_block(s, b, l) {memcpy(&s->pending_buf[s->pending], (b), (l)); s->pending += (l);}
 
 
 #define MIN_LOOKAHEAD (MAX_MATCH+MIN_MATCH+1)

--- a/trees.c
+++ b/trees.c
@@ -1220,7 +1220,5 @@ local void copy_block(s, buf, len, header)
 #ifdef DEBUG
     s->bits_sent += (ulg)len<<3;
 #endif
-    while (len--) {
-        put_byte(s, *buf++);
-    }
+    put_block(s, buf, len);
 }


### PR DESCRIPTION
It now uses memcpy to write large blocks of data instead of taking a slow byte at a time approach.

Some benchmarks using the samtools program (https://github.com/samtools/samtools/) which supports an uncompressed deflate stream (ie level 0, using checksums only - useful for when piping the output file into another tool and avoiding expensive encode/decode operations).

```
@ [tmp/zlib]; time  LD_PRELOAD=`pwd`/libz.so ~/work/samtools_master/samtools/samtools view -u -o /dev/null /tmp/_

real 0m9.258s
user 0m8.958s
sys  0m0.306s

@ [tmp/zlib]; time  LD_PRELOAD=`pwd`/libz.so ~/work/samtools_master/samtools/samtools view -u -o /dev/null /tmp/_

real 0m4.131s
user 0m3.813s
sys  0m0.318s
```

Perf record gives these figures for the _tr_stored_block() function before and after the change.

```
 57.41%         21309  samtools  libz.so.1.2.8       [.] _tr_stored_block
 23.76%          8818  samtools  libz.so.1.2.8       [.] crc32
  7.62%          2830  samtools  libc-2.19.so        [.] __memcpy_sse2_unaligned
  3.42%          1272  samtools  [kernel.kallsyms]   [k] 0xffffffff8104f45a
  ...


 55.89%          9264  samtools  libz.so.1.2.8       [.] crc32
 20.26%          3356  samtools  libc-2.19.so        [.] __memcpy_sse2_unaligned
  8.29%          1376  samtools  [kernel.kallsyms]   [k] 0xffffffff8104f45a
  ...
  0.01%             1  samtools  libz.so.1.2.8       [.] _tr_stored_block
```
