### PR TITLE
miniunz.c: Ensure string_method is initialized

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -275,6 +275,8 @@ int do_list(uf)
               string_method="Defl:X";
             else if ((iLevel==2) || (iLevel==3))
               string_method="Defl:F"; /* 2:fast , 3 : extra fast*/
+            else
+              string_method="Unkn. ";
         }
         else
         if (file_info.compression_method==Z_BZIP2ED)


### PR DESCRIPTION
cppcheck reports:
[contrib/minizip/miniunz.c:288]: (error) Uninitialized variable: string_method