### PR TITLE
Fix encoding of C# sources of DotZLib

### DIFF
--- a/contrib/dotzlib/DotZLib/ChecksumImpl.cs
+++ b/contrib/dotzlib/DotZLib/ChecksumImpl.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/CircularBuffer.cs
+++ b/contrib/dotzlib/DotZLib/CircularBuffer.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/CodecBase.cs
+++ b/contrib/dotzlib/DotZLib/CodecBase.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/Deflater.cs
+++ b/contrib/dotzlib/DotZLib/Deflater.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/DotZLib.cs
+++ b/contrib/dotzlib/DotZLib/DotZLib.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/GZipStream.cs
+++ b/contrib/dotzlib/DotZLib/GZipStream.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/Inflater.cs
+++ b/contrib/dotzlib/DotZLib/Inflater.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/contrib/dotzlib/DotZLib/UnitTests.cs
+++ b/contrib/dotzlib/DotZLib/UnitTests.cs
@@ -1,5 +1,5 @@
 //
-// © Copyright Henrik Ravn 2004
+// Copyright (C) Henrik Ravn 2004
 //
 // Use, modification and distribution are subject to the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)


### PR DESCRIPTION
Use ASCII for non-ASCII characters in C# sources of DotZLib