### PR TITLE
Corrected location of Visual Studio project files

### DIFF
--- a/win32/VisualC.txt
+++ b/win32/VisualC.txt
@@ -1,3 +1,3 @@
 
 To build zlib using the Microsoft Visual C++ environment,
-use the appropriate project from the projects/ directory.
+use the appropriate project from the contrib/vstudio directory.


### PR DESCRIPTION
There is no projects directory as referenced here. The VC project files are in contrib/vstudio. Relatedly, I suggest merging this two-line text file into the Win32 Readme, preferably on top somewhere.
