### PR TITLE
contrib: masmx64: Add z_const qualifiers to struct inffast_ar members

### DIFF
--- a/contrib/masmx64/inffas8664.c
+++ b/contrib/masmx64/inffas8664.c
@@ -83,8 +83,8 @@
 /* ar offset                              register */
 /*  0    0 */ void *esp;                /* esp save */
 /*  8    4 */ void *ebp;                /* ebp save */
-/* 16    8 */ unsigned char FAR *in;    /* esi rsi  local strm->next_in */
-/* 24   12 */ unsigned char FAR *last;  /*     r9   while in < last */
+/* 16    8 */ z_const unsigned char FAR *in;    /* esi rsi  local strm->next_in */
+/* 24   12 */ z_const unsigned char FAR *last;  /*     r9   while in < last */
 /* 32   16 */ unsigned char FAR *out;   /* edi rdi  local strm->next_out */
 /* 40   20 */ unsigned char FAR *beg;   /*          inflate()'s init next_out */
 /* 48   24 */ unsigned char FAR *end;   /*     r10  while out < end */


### PR DESCRIPTION
When building inffas8664.c with ZLIB_CONST defined in MSVC, the
following warning occurs:

  inffas8664.c(128): warning C4090: '=' : different 'const' qualifiers

Fix this by adding constness qualifiers to the `in' and`last' members
of struct inffast_ar as they get set from the respective members of
z_stream which are marked with z_const.
