### PR TITLE
Fix MSVC x64 z_size_t warnings

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -316,7 +316,7 @@ local z_size_t gz_read(state, buf, len)
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -397,7 +397,7 @@ int ZEXPORT gzread(file, buf, len)
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -469,7 +469,7 @@ int ZEXPORT gzgetc(file)
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -208,7 +208,7 @@ local z_size_t gz_write(state, buf, len)
                               state->in);
             copy = state->size - have;
             if (copy > len)
-                copy = len;
+                copy = (unsigned)len;
             memcpy(state->in + have, buf, copy);
             state->strm.avail_in += copy;
             state->x.pos += copy;
@@ -228,7 +228,7 @@ local z_size_t gz_write(state, buf, len)
         do {
             unsigned n = (unsigned)-1;
             if (n > len)
-                n = len;
+                n = (unsigned)len;
             state->strm.avail_in = n;
             state->x.pos += n;
             if (gz_comp(state, Z_NO_FLUSH) == -1)

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -367,7 +367,11 @@ int ZEXPORT gzputs(file, str)
 
     /* write string */
     len = strlen(str);
-    ret = gz_write(state, str, len);
+    /* check if string length will fit in signed int */
+    ret = (int)len;
+    if (ret < 0 || (unsigned)ret != len)
+        return -1;
+    ret = (int)gz_write(state, str, len);
     return ret == 0 && len != 0 ? -1 : ret;
 }
 

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -500,7 +500,7 @@ void file_uncompress(file)
     char *infile, *outfile;
     FILE  *out;
     gzFile in;
-    unsigned len = strlen(file);
+    z_size_t len = strlen(file);
 
     if (len + strlen(GZ_SUFFIX) >= sizeof(buf)) {
         fprintf(stderr, "%s: filename too long\n", prog);


### PR DESCRIPTION
All seems well (tested on VS2013 & 2015, WinSDK 7.0 & 7.1, MSVC 6.0, OSX 10.11.6), but VS2013 x64 (and probably other MSVC x64 versions) issues some C4267 cast size_t warnings. These few commits should hush the warnings, hopefully without breaking anything.

Note that commit 341f9da53e every so slightly changes behavior of gzputs(), because it will now return -1 if the string is too long to fit inside a signed int. Maybe something similar should be done for other functions, but I haven't really looked into this (mainly because there are no compiler warnings, and hey, I'm lazy).