### PR TITLE
contrib/masmx64/iffas8664.c: fix rare 32 vs 64 alignment issue

### DIFF
--- a/contrib/masmx64/inffas8664.c
+++ b/contrib/masmx64/inffas8664.c
@@ -144,7 +144,7 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
 
     /* align in on 1/2 hold size boundary */
     while (((size_t)(void *)ar.in & (sizeof(ar.hold) / 2 - 1)) != 0) {
-        ar.hold += (unsigned long)*ar.in++ << ar.bits;
+        ar.hold += (size_t)*ar.in++ << ar.bits;
         ar.bits += 8;
     }
 


### PR DESCRIPTION
unsigned long is only 32 bit on win64, while hold (and size_t) are
64 bit.

If the caller sometimes changes the alignment of the input data
(for example, while moving data in a fixed input buffer to make room
for more data), then there are rarish cases that need to preserve
more than 32 bits for this alignment loop to work correctly.
Especially if both input and output are regularly using Z_SYNC_FLUSH,
to support bi-directional streaming message protocols without
arbitrarily long delays.

---

I first tried to send this to zlib@gzip.org in 2013, but never got a response.
I figured it might be batched up and dealt with the next time zlib had a
more substantial release, but the recent 2017 activity does not seem to
include it.

It is a bit tricky to reproduce the corruption caused by this bug
in a debuggable way in the large application it was seen in, but the
re-alignment and flushing things mentioned above seem to be key.  After
spending a couple days finding the problem in 2013 I was able to internally
demonstrate with a smallish test program and sensitive data, but I didn't
take the time to clean it up into a nice demo with insensitive data.  If you
 really need such a demo, I could try to find it in my old notes at my day
 job, and clean it up, although I rather dislike working under windows.