### PR TITLE
Make zlib build correctly with newer Windows CE versions

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -136,8 +136,8 @@ const char * ZEXPORT zError(err)
     return ERR_MSG(err);
 }
 
-#if defined(_WIN32_WCE)
-    /* The Microsoft C Run-Time Library for Windows CE doesn't have
+#if defined(_WIN32_WCE) && _WIN32_WCE < 0x800
+    /* The older Microsoft C Run-Time Library for Windows CE doesn't have
      * errno.  We define it as a global variable to simplify porting.
      * Its value is always 0 and should not be used.
      */


### PR DESCRIPTION
Newer versions of Windows CE (>=0800) seem to already define the variable.