### PR TITLE
Fix coverity defect 1399504 - Nesting level does not match indentation

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -599,8 +599,9 @@ int ZEXPORT deflateParams(strm, level, strategy)
         if (s->level == 0 && s->matches != 0) {
             if (s->matches == 1)
                 slide_hash(s);
-            else
+            else {
                 CLEAR_HASH(s);
+            }
             s->matches = 0;
         }
         s->level = level;


### PR DESCRIPTION
Only the first declaration of the macro will be executed in the first, the rest outside of the if