### PR TITLE
Fix coverity defect 1399504 - Nesting level does not match indentation

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -189,9 +189,10 @@ local const config configuration_table[10] = {
  * Initialize the hash table (avoiding 64K overflow for 16 bit systems).
  * prev[] will be initialized on the fly.
  */
-#define CLEAR_HASH(s) \
+#define CLEAR_HASH(s) {\
     s->head[s->hash_size-1] = NIL; \
-    zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
+    zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head)); \
+}
 
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32


### PR DESCRIPTION
Only the first declaration of the macro will be executed in the first, the rest outside of the if