### PR TITLE
minizip: fix gcc warnings

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -54,6 +54,9 @@
 # include <utime.h>
 #endif
 
+#ifdef unix
+#include <sys/stat.h>
+#endif
 
 #include "unzip.h"
 
@@ -96,8 +99,7 @@ void change_file_date(filename,dosdate,tmu_date)
   LocalFileTimeToFileTime(&ftLocal,&ftm);
   SetFileTime(hFile,&ftm,&ftLastAcc,&ftm);
   CloseHandle(hFile);
-#else
-#ifdef unix || __APPLE__
+#elif defined(unix) || defined(__APPLE__)
   struct utimbuf ut;
   struct tm newdate;
   newdate.tm_sec = tmu_date.tm_sec;
@@ -114,7 +116,6 @@ void change_file_date(filename,dosdate,tmu_date)
   ut.actime=ut.modtime=mktime(&newdate);
   utime(filename,&ut);
 #endif
-#endif
 }
 
 
@@ -127,9 +128,7 @@ int mymkdir(dirname)
     int ret=0;
 #ifdef _WIN32
     ret = _mkdir(dirname);
-#elif unix
-    ret = mkdir (dirname,0775);
-#elif __APPLE__
+#elif defined(unix) || defined(__APPLE__)
     ret = mkdir (dirname,0775);
 #endif
     return ret;

--- a/contrib/minizip/minizip.c
+++ b/contrib/minizip/minizip.c
@@ -93,8 +93,7 @@ uLong filetime(f, tmzip, dt)
   }
   return ret;
 }
-#else
-#ifdef unix || __APPLE__
+#elif defined(unix) || defined(__APPLE__)
 uLong filetime(f, tmzip, dt)
     char *f;               /* name of file to get info on */
     tm_zip *tmzip;         /* return value: access, modific. and creation times */
@@ -144,7 +143,6 @@ uLong filetime(f, tmzip, dt)
 {
     return 0;
 }
-#endif
 #endif
 
 


### PR DESCRIPTION
miniunz.c:100:13: warning: extra tokens at end of #ifdef directive
 #ifdef unix || __APPLE__
             ^~
miniunz.c: In function ‘mymkdir’:
miniunz.c:131:11: warning: implicit declaration of function ‘mkdir’ [-Wimplicit-function-declaration]
     ret = mkdir (dirname,0775);
           ^~~~~
minizip.c:97:13: warning: extra tokens at end of #ifdef directive
 #ifdef unix || __APPLE__