### PR TITLE
minizip: don't disable uncrypt everywhere

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -68,10 +68,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NOUNCRYPT
-        #define NOUNCRYPT
-#endif
-
 #include "zlib.h"
 #include "unzip.h"
 


### PR DESCRIPTION
.. and rather have it again as an option.

We have this patch applied in Fedora since v1.2.15.