### PR TITLE
minizip: fix gcc warning about misleading indent

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -526,8 +526,8 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
         break;
       }
 
-      if (uPosFound!=0)
-        break;
+    if (uPosFound!=0)
+      break;
   }
   TRYFREE(buf);
   return uPosFound;


### PR DESCRIPTION
```
zip.c: In function 'zip64local_SearchCentralDir':
zip.c:521:5: warning: this 'for' clause does not guard...
[-Wmisleading-indentation]
     for (i=(int)uReadSize-3; (i--)>0;)
     ^~~
zip.c:529:7: note: ...this statement, but the latter is
misleadingly indented as if it is guarded by the 'for'
       if (uPosFound!=0)
       ^~
```