### PR TITLE
fix MSVC signed vs. unsigned warning by using an explicit cast

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -314,7 +314,7 @@ local z_size_t gz_read(state, buf, len)
     got = 0;
     do {
         /* set n to the maximum amount of len that fits in an unsigned int */
-        n = -1;
+        n = (unsigned)-1;
         if (n > len)
             n = len;
 


### PR DESCRIPTION
MSVC 2015 complains:

gzread.c(317): warning C4245: '=': conversion from 'int' to 'unsigned int', signed/unsigned mismatch

the conversion is wanted, as the comment tells, make it explicit