### PR TITLE
Add MinGW-w64 Makefile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@
 *.o
 *.dylib
 
+*.dll
+*.exe
+
 *.gcda
 *.gcno
 *.gcov

--- a/win32/Makefile.mingw-w64
+++ b/win32/Makefile.mingw-w64
@@ -1,0 +1,163 @@
+# Makefile for zlib, derived from Makefile.gcc.
+# Modified for mingw-w64 by James C. Adduono, 2016-02-08.
+# Last updated: Feb 2017.
+# Tested under MinGW-w64.
+
+# Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler.
+# For conditions of distribution and use, see copyright notice in zlib.h
+
+# To compile, or to compile and test, type from the top level zlib directory:
+#
+#   make -fwin32/Makefile.mingw-w64;  make test testdll -fwin32/Makefile.mingw-w64
+#
+# To install zlib1.dll, libz.dll.a, libz.a, zconf.h, zlib.h, and zlib.pc
+# in the system directories, type:
+#
+#   make install -fwin32/Makefile.mingw-w64
+#
+
+STATICLIB = libz.a
+SHAREDLIB = zlib1.dll
+IMPLIB    = libz.dll.a
+
+#LOC = -DASMV
+#LOC = -DZLIB_DEBUG -g
+
+HOST ?= x86_64-w64-mingw32
+CROSS_COMPILE ?= $(HOST)-
+PREFIX ?= /usr/$(HOST)
+EXEC_PREFIX ?= $(PREFIX)
+
+LIBRARY_PATH ?= $(PREFIX)/lib
+BINARY_PATH ?= $(PREFIX)/bin
+INCLUDE_PATH ?= $(PREFIX)/include
+
+CC = $(CROSS_COMPILE)gcc
+CFLAGS += $(LOC) -O3 -Wall
+
+AS = $(CC)
+ASFLAGS += $(LOC) -Wall
+
+LD = $(CC)
+LDFLAGS += $(LOC)
+
+AR = $(CROSS_COMPILE)ar
+ARFLAGS = rcs
+
+RC = $(CROSS_COMPILE)windres
+RCFLAGS = --define GCC_WINDRES
+
+STRIP = $(CROSS_COMPILE)strip
+
+CP = cp -fp
+# If GNU install is available, replace $(CP) with install.
+INSTALL = $(CP)
+RM = rm -f
+
+OBJS = adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o \
+       gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o
+#OBJA = match.o
+
+all: $(STATICLIB) $(SHAREDLIB) $(IMPLIB) example.exe minigzip.exe example_d.exe minigzip_d.exe
+
+lib: $(STATICLIB) $(SHAREDLIB) $(IMPLIB)
+
+test: example.exe minigzip.exe
+	./example
+	echo hello world | ./minigzip | ./minigzip -d
+
+testdll: example_d.exe minigzip_d.exe
+	./example_d
+	echo hello world | ./minigzip_d | ./minigzip_d -d
+
+.c.o:
+	$(CC) $(CFLAGS) -c -o $@ $<
+
+.S.o:
+	$(AS) $(ASFLAGS) -c -o $@ $<
+
+$(STATICLIB): $(OBJS) $(OBJA)
+	$(AR) $(ARFLAGS) $@ $(OBJS) $(OBJA)
+
+$(IMPLIB): $(SHAREDLIB)
+
+$(SHAREDLIB): win32/zlib.def $(OBJS) $(OBJA) zlibrc.o
+	$(CC) -shared -Wl,--out-implib,$(IMPLIB) $(LDFLAGS) \
+	-o $@ win32/zlib.def $(OBJS) $(OBJA) zlibrc.o
+	$(STRIP) $@
+
+example.exe: example.o $(STATICLIB)
+	$(LD) $(LDFLAGS) -o $@ example.o $(STATICLIB)
+	$(STRIP) $@
+
+minigzip.exe: minigzip.o $(STATICLIB)
+	$(LD) $(LDFLAGS) -o $@ minigzip.o $(STATICLIB)
+	$(STRIP) $@
+
+example_d.exe: example.o $(IMPLIB)
+	$(LD) $(LDFLAGS) -o $@ example.o $(IMPLIB)
+	$(STRIP) $@
+
+minigzip_d.exe: minigzip.o $(IMPLIB)
+	$(LD) $(LDFLAGS) -o $@ minigzip.o $(IMPLIB)
+	$(STRIP) $@
+
+example.o: test/example.c zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -c -o $@ test/example.c
+
+minigzip.o: test/minigzip.c zlib.h zconf.h
+	$(CC) $(CFLAGS) -I. -c -o $@ test/minigzip.c
+
+zlibrc.o: win32/zlib1.rc
+	$(RC) $(RCFLAGS) -o $@ win32/zlib1.rc
+
+.PHONY: install uninstall clean
+
+install: zlib.h zconf.h $(STATICLIB) $(IMPLIB) $(SHAREDLIB)
+	-@mkdir -p '$(INCLUDE_PATH)'
+	-@mkdir -p '$(LIBRARY_PATH)' '$(LIBRARY_PATH)'/pkgconfig
+	-@mkdir -p '$(BINARY_PATH)'
+	-$(INSTALL) zlib.h '$(INCLUDE_PATH)'
+	-$(INSTALL) zconf.h '$(INCLUDE_PATH)'
+	-$(INSTALL) $(STATICLIB) '$(LIBRARY_PATH)'
+	-$(INSTALL) $(SHAREDLIB) '$(BINARY_PATH)'
+	-$(INSTALL) $(IMPLIB) '$(LIBRARY_PATH)'
+	sed \
+		-e 's|@prefix@|${PREFIX}|g' \
+		-e 's|@exec_prefix@|${EXEC_PREFIX}|g' \
+		-e 's|@libdir@|$(LIBRARY_PATH)|g' \
+		-e 's|@sharedlibdir@|$(LIBRARY_PATH)|g' \
+		-e 's|@includedir@|$(INCLUDE_PATH)|g' \
+		-e 's|@VERSION@|'`sed -n -e '/VERSION "/s/.*"\(.*\)".*/\1/p' zlib.h`'|g' \
+		zlib.pc.in > '$(LIBRARY_PATH)'/pkgconfig/zlib.pc
+
+uninstall:
+	-$(RM) '$(INCLUDE_PATH)'/zlib.h
+	-$(RM) '$(INCLUDE_PATH)'/zconf.h
+	-$(RM) '$(LIBRARY_PATH)'/$(STATICLIB)
+	-$(RM) '$(BINARY_PATH)'/$(SHAREDLIB)
+	-$(RM) '$(LIBRARY_PATH)'/$(IMPLIB)
+
+clean:
+	-$(RM) $(STATICLIB)
+	-$(RM) $(SHAREDLIB)
+	-$(RM) $(IMPLIB)
+	-$(RM) *.o
+	-$(RM) *.exe
+	-$(RM) foo.gz
+
+adler32.o: zlib.h zconf.h
+compress.o: zlib.h zconf.h
+crc32.o: crc32.h zlib.h zconf.h
+deflate.o: deflate.h zutil.h zlib.h zconf.h
+gzclose.o: zlib.h zconf.h gzguts.h
+gzlib.o: zlib.h zconf.h gzguts.h
+gzread.o: zlib.h zconf.h gzguts.h
+gzwrite.o: zlib.h zconf.h gzguts.h
+inffast.o: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
+inflate.o: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
+infback.o: zutil.h zlib.h zconf.h inftrees.h inflate.h inffast.h
+inftrees.o: zutil.h zlib.h zconf.h inftrees.h
+trees.o: deflate.h zutil.h zlib.h zconf.h trees.h
+uncompr.o: zlib.h zconf.h
+zutil.o: zutil.h zlib.h zconf.h


### PR DESCRIPTION
I was having a bit of trouble with Makefile.gcc so I made a few modifications under a new name, ex. Makefile.mingw-w64

Maybe Makefile.mingw would be a better name, as you can probably just use
`HOST=i586-pc-mingw32 make -fwin32/Makefile.mingw-w64`
to have it compile for 32-bit.

It should happily compile & install to `/usr/x86_64-w64-mingw32` with just `make -fwin32/Makefile.mingw-w64`

It builds both shared and static libraries. You can avoid building the executable files by using:
`make lib -fwin32/Makefile.mingw-w64`

HOST defaults to x86_64-w64-mingw32.
Install location can be set with PREFIX. (defaults to /usr/$HOST)

```
root@gallifrey:/home/jc/build/lib/zlib# make -fwin32/Makefile.mingw-w64
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o adler32.o adler32.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o compress.o compress.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o crc32.o crc32.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o deflate.o deflate.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o gzclose.o gzclose.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o gzlib.o gzlib.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o gzread.o gzread.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o gzwrite.o gzwrite.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o infback.o infback.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o inffast.o inffast.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o inflate.o inflate.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o inftrees.o inftrees.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o trees.o trees.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o uncompr.o uncompr.c
x86_64-w64-mingw32-gcc  -O3 -Wall -c -o zutil.o zutil.c
x86_64-w64-mingw32-ar rcs libz.a adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o 
x86_64-w64-mingw32-windres --define GCC_WINDRES -o zlibrc.o win32/zlib1.rc
x86_64-w64-mingw32-gcc -shared -Wl,--out-implib,libz.dll.a  \
-o zlib1.dll win32/zlib.def adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o  zlibrc.o
x86_64-w64-mingw32-strip zlib1.dll
x86_64-w64-mingw32-gcc  -O3 -Wall -I. -c -o example.o test/example.c
x86_64-w64-mingw32-gcc  -o example.exe example.o libz.a
x86_64-w64-mingw32-strip example.exe
x86_64-w64-mingw32-gcc  -O3 -Wall -I. -c -o minigzip.o test/minigzip.c
x86_64-w64-mingw32-gcc  -o minigzip.exe minigzip.o libz.a
x86_64-w64-mingw32-strip minigzip.exe
x86_64-w64-mingw32-gcc  -o example_d.exe example.o libz.dll.a
x86_64-w64-mingw32-strip example_d.exe
x86_64-w64-mingw32-gcc  -o minigzip_d.exe minigzip.o libz.dll.a
x86_64-w64-mingw32-strip minigzip_d.exe
root@gallifrey:/home/jc/build/lib/zlib# 
```

Successfully managed to use zlib1.dll under nginx.exe :)