### PR TITLE
Make 'make check' return failure if test fails

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -91,7 +91,7 @@ teststatic: static
 	  echo '		*** zlib test OK ***'; \
 	else \
 	  echo '		*** zlib test FAILED ***'; false; \
-	fi; \
+	fi
 	rm -f $$TMPST
 
 testshared: shared
@@ -104,7 +104,7 @@ testshared: shared
 	  echo '		*** zlib shared test OK ***'; \
 	else \
 	  echo '		*** zlib shared test FAILED ***'; false; \
-	fi; \
+	fi
 	rm -f $$TMPSH
 
 test64: all64
@@ -113,7 +113,7 @@ test64: all64
 	  echo '		*** zlib 64-bit test OK ***'; \
 	else \
 	  echo '		*** zlib 64-bit test FAILED ***'; false; \
-	fi; \
+	fi
 	rm -f $$TMP64
 
 infcover.o: $(SRCDIR)test/infcover.c $(SRCDIR)zlib.h zconf.h


### PR DESCRIPTION
Currently, make returns success because the last command (rm -f) succeeds.

Signed-off-by: Alexey Neyman <stilor@att.net>