### PR TITLE
Fix so that if xlc is used on AIX, do not use gcc

### DIFF
--- a/configure
+++ b/configure
@@ -168,15 +168,20 @@ EOF
 test -z "$CC" && echo Checking for ${CROSS_PREFIX}gcc... | tee -a configure.log
 cc=${CC-${CROSS_PREFIX}gcc}
 cflags=${CFLAGS-"-O3"}
+xlc=0;
+
 # to force the asm version use: CFLAGS="-O3 -DASMV" ./configure
 case "$cc" in
   *gcc*) gcc=1 ;;
   *clang*) gcc=1 ;;
+  *xlc*) xlc=1 ;;
 esac
-case `$cc -v 2>&1` in
-  *gcc*) gcc=1 ;;
-  *clang*) gcc=1 ;;
-esac
+if test "$xlc" -eq 0; then
+  case `$cc -v 2>&1` in
+    *gcc*) gcc=1 ;;
+    *clang*) gcc=1 ;;
+  esac
+fi
 
 show $cc -c $test.c
 if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then


### PR DESCRIPTION
xlc does not understand -v. It is -qversion
Without this, shared libraries do not get built because configure
still thinks it is using gcc and those flags are incorrect for xlc