### PR TITLE
Do not use WINAPI_FAMILY_ONE_PARTITION if not defined

### DIFF
--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -27,7 +27,7 @@
 
 
 // see Include/shared/winapifamily.h in the Windows Kit
-#if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
+#if defined(WINAPI_FAMILY_ONE_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
 #if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
 #define IOWIN32_USING_WINRT_API 1
 #endif


### PR DESCRIPTION
This fixes a compile time warning "C4067: unexpected tokens following preprocessor directive - expected a newline" (on VS2013 with Windows 8.1 SDK) and is is a follow up for commit 89e335abb49cd5c7d29d94e8f506d3f8ed71315a.

Also see issue #49 and issue #77.