### PR TITLE
adding  to gitignore since it is autogenerated file at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /zlib.pc
 
 .DS_Store
+zconf.h.included


### PR DESCRIPTION
The file zconf.h.included being autogenerated during the build process. This fact making git module tree dirty which is require additional effort during the submodule management.