### PR TITLE
Protect the CLEAR_HASH macro

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -190,8 +190,10 @@ local const config configuration_table[10] = {
  * prev[] will be initialized on the fly.
  */
 #define CLEAR_HASH(s) \
+do { \
     s->head[s->hash_size-1] = NIL; \
-    zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head));
+    zmemzero((Bytef *)s->head, (unsigned)(s->hash_size-1)*sizeof(*s->head)); \
+} while (0)
 
 /* ===========================================================================
  * Slide the hash table when sliding the window down (could be avoided with 32


### PR DESCRIPTION
We recently updated the zlib fork in Varnish Cache [1] and our periodic Coverity check reported this:

    /lib/libvgz/deflate.c: 605 in deflateParams()
    599     }
    600     if (s->level != level) {
    601         if (s->level == 0 && s->matches != 0) {
    602             if (s->matches == 1)
    603                 slide_hash(s);
    604             else
    >>> CID 1401053:  Control flow issues  (NESTING_INDENT_MISMATCH)
    >>> The macro on this line expands into multiple statements, only
    >>> the first of which is nested within the preceding parent while
    >>> the rest are not.
    605                 CLEAR_HASH(s);
    606             s->matches = 0;
    607         }
    608         s->level = level;
    609         s->max_lazy_match   = configuration_table[level].max_lazy;
    610         s->good_match       = configuration_table[level].good_length;

This was introduced in 9dc5a8585f429109ef1948ab71b6b71bfa7181e2 and fixed downstream [2].

[1] https://github.com/varnishcache/varnish-cache/commit/5fae56145cc83007df6dfcc08f9b91134dafd757
[2] https://github.com/varnishcache/varnish-cache/commit/ea111153098fe636f7c42ab8da4efdc5954e894e