### PR TITLE
Allow for static-only builds on mingw32

### DIFF
--- a/win32/Makefile.gcc
+++ b/win32/Makefile.gcc
@@ -71,7 +71,11 @@ OBJS = adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o \
        gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o
 OBJA =
 
-all: $(STATICLIB) $(SHAREDLIB) $(IMPLIB) example.exe minigzip.exe example_d.exe minigzip_d.exe
+all: $(STATICLIB) example.exe minigzip.exe
+
+ifeq ($(SHARED_MODE),1)
+all: $(SHAREDLIB) $(IMPLIB) example_d.exe minigzip_d.exe
+endif
 
 test: example.exe minigzip.exe
 	./example
@@ -125,7 +129,7 @@ zlibrc.o: win32/zlib1.rc
 .PHONY: install uninstall clean
 
 install: zlib.h zconf.h $(STATICLIB) $(IMPLIB)
-	@if test -z "$(DESTDIR)$(INCLUDE_PATH)" -o -z "$(DESTDIR)$(LIBRARY_PATH)" -o -z "$(DESTDIR)$(BINARY_PATH)"; then \
+	@if test -z "$(INCLUDE_PATH)" -o -z "$(LIBRARY_PATH)" -o -z "$(BINARY_PATH)"; then \
 		echo INCLUDE_PATH, LIBRARY_PATH, and BINARY_PATH must be specified; \
 		exit 1; \
 	fi


### PR DESCRIPTION
Currently, the Makefile always attempts to build the dll. Setting
SHAREDLIB/IMPLIB to empty does not help as 'make all' still tries
to use them to link minigzip_d/example_d.

Also, check INCLUDE_PATH/LIBRARY_PATH/BINARY_PATH for being empty
without prepending DESTDIR first. Otherwise, if DESTDIR is not empty,
the check passes and everything is installed into a single directory.

Signed-off-by: Alexey Neyman <stilor@att.net>