### PR TITLE
CMake on MinGW: Add VERBATIM to add_custom_command().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,8 @@ if(MINGW)
                             -I ${CMAKE_CURRENT_SOURCE_DIR}
                             -I ${CMAKE_CURRENT_BINARY_DIR}
                             -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
+                            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc
+                       VERBATIM)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
 endif(MINGW)
 


### PR DESCRIPTION
This fixes a zlib build error on MinGW for the CMake build.  If spaces occur within the paths, the build on MinGW will fail unless VERBATIM is used in the CMakeLists.txt.

The origin of this patch is here: https://gitlab.kitware.com/third-party/zlib/commit/cb98c54