### PR TITLE
Fix casts revealed by compiling in MSVC

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -316,7 +316,7 @@ local z_size_t gz_read(state, buf, len)
         /* set n to the maximum amount of len that fits in an unsigned int */
         n = -1;
         if (n > len)
-            n = len;
+            n = (unsigned)len;
 
         /* first just try copying data from the output buffer */
         if (state->x.have) {
@@ -397,7 +397,7 @@ int ZEXPORT gzread(file, buf, len)
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0 && state->err != Z_OK && state->err != Z_BUF_ERROR)
@@ -469,7 +469,7 @@ int ZEXPORT gzgetc(file)
     }
 
     /* nothing there -- try gz_read() */
-    ret = gz_read(state, buf, 1);
+    ret = (int)gz_read(state, buf, 1);
     return ret < 1 ? -1 : buf[0];
 }
 


### PR DESCRIPTION
Five already safe:
gzread.c(319): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
gzread.c(400): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
gzread.c(472): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
gzwrite.c(212): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data
gzwrite.c(232): warning C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data

One requires more argument validation:
gzwrite.c(371): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data