### PR TITLE
add option for linking with the static runtime of msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,13 @@ set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation d
 set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
 set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
 
+if(MSVC)
+    option(BUILD_WITH_STATIC_MSVC_RUNTIME "Link with the static vc runtime" OFF)
+    if(BUILD_WITH_STATIC_MSVC_RUNTIME)
+        include(cmake/msvc_static_runtime.cmake)
+    endif()
+endif()
+
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)

--- a/cmake/msvc_static_runtime.cmake
+++ b/cmake/msvc_static_runtime.cmake
@@ -1,0 +1,15 @@
+# CMAKE_CONFIGURATION_TYPES is empty on non-IDE generators (Ninja, NMake)
+# and that's why we also use CMAKE_BUILD_TYPE to cover for those generators.
+# For IDE generators, CMAKE_BUILD_TYPE is usually empty
+foreach(config_type ${CMAKE_CONFIGURATION_TYPES} ${CMAKE_BUILD_TYPE})
+    string(TOUPPER ${config_type} upper_config_type)
+    set(flag_var "CMAKE_C_FLAGS_${upper_config_type}")
+    if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif()
+endforeach()
+
+# clean up
+set(upper_config_type)
+set(config_type)
+set(flag_var)


### PR DESCRIPTION
the option is available only under `MSVC` and it is `OFF` by default