### PR TITLE
Speed up inflate_fast by up to 1.5x on x86_64.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(VERSION "1.2.11")
 
 option(ASM686 "Enable building i686 assembly implementation")
 option(AMD64 "Enable building amd64 assembly implementation")
+option(INFFAST64 "Enable 64 bit inflate_fast implementation")
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
@@ -160,6 +161,11 @@ if(MSVC)
 	if(ZLIB_ASMS)
 		add_definitions(-DASMV -DASMINF)
 	endif()
+endif()
+
+if(INFFAST64)
+	add_definitions(-DINFLATE_FAST64)
+	list(APPEND ZLIB_SRCS contrib/inffast64/inffast64.c)
 endif()
 
 # parse the full version number from zlib.h and include in ZLIB_FULL_VERSION

--- a/contrib/README.contrib
+++ b/contrib/README.contrib
@@ -32,6 +32,9 @@ gcc_gvmat64/by Gilles Vollant <info@winimage.com>
 infback9/   by Mark Adler <madler@alumni.caltech.edu>
         Unsupported diffs to infback to decode the deflate64 format
 
+inffast64/  by Nigel Tao <nigeltao@google.com>
+        64 bit version of inffast.c. No asm, 1.5x faster on x86 64.
+
 inflate86/  by Chris Anderson <christop@charm.net>
         Tuned x86 gcc asm code to replace inflate_fast()
 

--- a/contrib/inffast64/inffast64.c
+++ b/contrib/inffast64/inffast64.c
@@ -1,3 +1,13 @@
+/* inffast64.c is a 64 bit version of inffast.c. Pure C, no asm.
+ * Copyright (C) 2017 Google.
+ *
+ * It benchmarks 1.5x faster than the top-level inffast.c, on x86 64. See
+ * https://gist.github.com/nigeltao/5deba67065a302ebe9ac342235a709c2
+ *
+ * The diff between this file and inffast.c can be seen at
+ * https://gist.github.com/nigeltao/2884d66f16fd3109184967a78cfea7a5
+ */
+
 /* inffast.c -- fast decoding
  * Copyright (C) 1995-2017 Mark Adler
  * For conditions of distribution and use, see copyright notice in zlib.h
@@ -11,8 +21,11 @@
 #ifdef ASMINF
 #  pragma message("Assembler code may have bugs -- use at your own risk")
 #elif INFLATE_FAST64
-/* Skip this implementation; use contrib/inffast64/inffast64.c instead. */
-#else
+
+#if defined(ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS) || \
+    defined(ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN)
+#include <stdint.h>
+#endif
 
 /*
    Decode literal, length, and distance codes and write out the resulting
@@ -45,10 +58,28 @@
       Therefore if strm->avail_in >= 6, then there is enough input to avoid
       checking for available input while decoding.
 
+    - On some architectures, it can be significantly faster (e.g. up to 1.2x
+      faster on x86_64) to load from strm->next_in 64 bits, or 8 bytes, at a
+      time, so INFLATE_FAST_MIN_HAVE == 8. This requires a little endian
+      architecture.
+
     - The maximum bytes that a single length/distance pair can output is 258
       bytes, which is the maximum length that can be coded.  inflate_fast()
       requires strm->avail_out >= 258 for each loop to avoid checking for
       output space.
+
+    - On some architectures, for length-distance copies, we similarly load and
+      store 8 bytes at a time, if the distance is at least 8. Again, this can
+      be significantly faster (e.g. up to 1.3x faster on x86_64). Rounding up
+      to a multiple of 8 gives INFLATE_FAST_MIN_LEFT == 264. This does not
+      require a little endian architecture. This always copies 8*L bytes (where
+      L is the smallest integer such that 8*L >= len, i.e. we round length up
+      to a multiple of 8), instead of only len bytes, but that's OK, as
+      subsequent iterations will fix the overrun.
+
+    - Combining those two optimizations for 64 bit unaligned loads gives up to
+      a 1.5x throughput improvement on x86_64.
+
  */
 void ZLIB_INTERNAL inflate_fast(strm, start)
 z_streamp strm;
@@ -67,7 +98,54 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
     unsigned whave;             /* valid bytes in the window */
     unsigned wnext;             /* window write index */
     unsigned char FAR *window;  /* allocated sliding window, if wsize != 0 */
-    unsigned long hold;         /* local strm->hold */
+
+    /* hold is a local copy of strm->hold. By default, hold satisfies the same
+       invariants that strm->hold does, namely that (hold >> bits) == 0. This
+       invariant is kept by loading bits into hold one byte at a time, like:
+
+       hold |= next_byte_of_input << bits; in++; bits += 8;
+
+       If we need to ensure that bits >= 15 then this code snippet is simply
+       repeated. Over one iteration of the outermost do/while loop, this
+       happens up to six times (48 bits of input), as described in the NOTES
+       above.
+
+       However, on some little endian architectures, it can be significantly
+       faster to load 64 bits once instead of 8 bits six times:
+
+       if (bits <= 16) {
+         hold |= next_8_bytes_of_input << bits; in += 6; bits += 48;
+       }
+
+       Unlike the simpler one byte load, shifting the next_8_bytes_of_input
+       by bits will overflow and lose those high bits, up to 2 bytes' worth.
+       The conservative estimate is therefore that we have read only 6 bytes
+       (48 bits). Again, as per the NOTES above, 48 bits is sufficient for the
+       rest of the iteration, and we will not need to load another 8 bytes.
+
+       Inside this function, we no longer satisfy (hold >> bits) == 0, but
+       this is not problematic, even if that overflow does not land on an 8 bit
+       byte boundary. Those excess bits will eventually shift down lower as the
+       Huffman decoder consumes input, and when new input bits need to be loaded
+       into the bits variable, the same input bits will be or'ed over those
+       existing bits. A bitwise or is idempotent: (a | b | b) equals (a | b).
+       Note that we therefore write that load operation as "hold |= etc" and not
+       "hold += etc".
+
+       Outside that loop, at the end of the function, hold is bitwise and'ed
+       with (1<<bits)-1 to drop those excess bits so that, on function exit, we
+       keep the invariant that (state->hold >> state->bits) == 0.
+
+       TODO: rename the bits variable to nbits, so that this block comment
+       is less confusing when discussing bits (the variable) and bits (one
+       eighth of a byte).
+       */
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+    uint64_t hold;
+#else
+    unsigned long hold;
+#endif
+
     unsigned bits;              /* local strm->bits */
     code const FAR *lcode;      /* local strm->lencode */
     code const FAR *dcode;      /* local strm->distcode */
@@ -105,10 +183,41 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
        input data or output space */
     do {
         if (bits < 15) {
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+            /* Example disassembly on __x86_64__:
+               49 8b 06              mov    (%r14),%rax
+               89 f1                 mov    %esi,%ecx
+               49 83 c6 06           add    $0x6,%r14
+               83 c6 30              add    $0x30,%esi
+               48 d3 e0              shl    %cl,%rax
+               48 09 c2              or     %rax,%rdx
+             */
+            hold |= *((uint64_t *)(in)) << bits;
+            in += 6;
+            bits += 48;
+#else
+            /* Example disassembly on __x86_64__:
+               45 0f b6 45 00        movzbl 0x0(%r13),%r8d
+               89 f1                 mov    %esi,%ecx
+               49 83 c5 02           add    $0x2,%r13
+               49 d3 e0              shl    %cl,%r8
+               8d 4e 08              lea    0x8(%rsi),%ecx
+               83 c6 10              add    $0x10,%esi
+               49 01 d0              add    %rdx,%r8
+               41 0f b6 55 ff        movzbl -0x1(%r13),%edx
+               48 d3 e2              shl    %cl,%rdx
+               4c 01 c2              add    %r8,%rdx
+             */
+            /* TODO: replace "hold += etc" with "hold |= etc", here and below,
+               to be consistent with the 64 bit unaligned code path. This is
+               only a comment for now so that the commit that introduced this
+               comment has no effect whatsoever on architectures without
+               ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN. */
             hold += (unsigned long)(*in++) << bits;
             bits += 8;
             hold += (unsigned long)(*in++) << bits;
             bits += 8;
+#endif
         }
         here = lcode[hold & lmask];
       dolen:
@@ -127,8 +236,14 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
             op &= 15;                           /* number of extra bits */
             if (op) {
                 if (bits < op) {
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+                    hold |= *((uint64_t *)(in)) << bits;
+                    in += 6;
+                    bits += 48;
+#else
                     hold += (unsigned long)(*in++) << bits;
                     bits += 8;
+#endif
                 }
                 len += (unsigned)hold & ((1U << op) - 1);
                 hold >>= op;
@@ -136,10 +251,16 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
             }
             Tracevv((stderr, "inflate:         length %u\n", len));
             if (bits < 15) {
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+                hold |= *((uint64_t *)(in)) << bits;
+                in += 6;
+                bits += 48;
+#else
                 hold += (unsigned long)(*in++) << bits;
                 bits += 8;
                 hold += (unsigned long)(*in++) << bits;
                 bits += 8;
+#endif
             }
             here = dcode[hold & dmask];
           dodist:
@@ -151,12 +272,18 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                 dist = (unsigned)(here.val);
                 op &= 15;                       /* number of extra bits */
                 if (bits < op) {
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+                    hold |= *((uint64_t *)(in)) << bits;
+                    in += 6;
+                    bits += 48;
+#else
                     hold += (unsigned long)(*in++) << bits;
                     bits += 8;
                     if (bits < op) {
                         hold += (unsigned long)(*in++) << bits;
                         bits += 8;
                     }
+#endif
                 }
                 dist += (unsigned)hold & ((1U << op) - 1);
 #ifdef INFLATE_STRICT
@@ -239,6 +366,22 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                             from = out - dist;  /* rest from output */
                         }
                     }
+
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS
+                    if (dist >= 8) {
+                        while (1) {
+                            *((uint64_t*)(out)) = *((uint64_t*)(from));
+                            if (len <= 8) {
+                                out += len;
+                                break;
+                            }
+                            out += 8;
+                            from += 8;
+                            len -= 8;
+                        }
+                        continue;
+                    }
+#endif
                     while (len > 2) {
                         *out++ = *from++;
                         *out++ = *from++;
@@ -253,6 +396,21 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
                 }
                 else {
                     from = out - dist;          /* copy direct from output */
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS
+                    if (dist >= 8) {
+                        while (1) {
+                            *((uint64_t*)(out)) = *((uint64_t*)(from));
+                            if (len <= 8) {
+                                out += len;
+                                break;
+                            }
+                            out += 8;
+                            from += 8;
+                            len -= 8;
+                        }
+                        continue;
+                    }
+#endif
                     do {                        /* minimum length is three */
                         *out++ = *from++;
                         *out++ = *from++;
@@ -326,4 +484,4 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
    - Moving len -= 3 statement into middle of loop
  */
 
-#endif /* !ASMINF && !INFLATE_FAST64 */
+#endif /* !ASMINF && INFLATE_FAST64 */

--- a/infback.c
+++ b/infback.c
@@ -480,7 +480,8 @@ void FAR *out_desc;
 
         case LEN:
             /* use inflate_fast() if we have enough input and output */
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;

--- a/inffast.h
+++ b/inffast.h
@@ -8,4 +8,55 @@
    subject to change. Applications should only use zlib.h.
  */
 
+
+
+#ifdef INFLATE_FAST64
+
+/* __x86_64__ is used by Clang and GCC. _M_X64 is used by MSVC.
+   __ppc64__ is used by Clang. __PPC64__ is used by GCC.
+   __aarch64__ is used by Clang and GCC.
+ */
+#if defined(__x86_64__) || defined(_M_X64) || \
+    defined(__ppc64__) || defined(__PPC__64) || defined(__aarch64__)
+
+#define ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS 1
+
+#if defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN 1
+#endif
+
+#endif
+
+#endif /* INFFLATE_FAST64 */
+
+
+
+/* If using 64 bit loads, round INFLATE_FAST_MIN_LEFT and INFLATE_FAST_MIN_HAVE
+   up to a multiple of 8.
+ */
+
+/* INFLATE_FAST_MIN_LEFT is the minimum number of output bytes that are left,
+   so that we can call inflate_fast safely with only one up front bounds check.
+   One length-distance code pair can copy up to 258 bytes.
+ */
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS
+#define INFLATE_FAST_MIN_LEFT 264
+#else
+#define INFLATE_FAST_MIN_LEFT 258
+#endif
+
+/* INFLATE_FAST_MIN_HAVE is the minimum number of input bytes that we have, so
+   that we can call inflate_fast safely with only one up front bounds check.
+   One length-distance code pair (as two Huffman encoded values of up to 15
+   bits each) plus any additional bits (up to 5 for length and 13 for distance)
+   can require reading up to 48 bits, or 6 bytes.
+ */
+#ifdef ZLIB_INTERNAL_HAVE_64_BIT_UNALIGNED_LOADS_LITTLE_ENDIAN
+#define INFLATE_FAST_MIN_HAVE 8
+#else
+#define INFLATE_FAST_MIN_HAVE 6
+#endif
+
+
+
 void ZLIB_INTERNAL inflate_fast OF((z_streamp strm, unsigned start));

--- a/inflate.c
+++ b/inflate.c
@@ -1042,7 +1042,8 @@ int flush;
         case LEN_:
             state->mode = LEN;
         case LEN:
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 inflate_fast(strm, out);
                 LOAD();


### PR DESCRIPTION
https://github.com/google/snappy is an unrelated compression format but
its snappy_unittest program is able to benchmark the snappy library and
the zlib library. We can re-purpose it, via LD_LIBRARY_PATH, to measure
different versions of zlib, such as before / after this commit.

snappy_unittest's output looks like:

testdata/alice29.txt                     :
ZLIB:   [b 1M] bytes 152089 ->  54404 35.8%  comp  19.6 MB/s  uncomp
258.2 MB/s
testdata/asyoulik.txt                    :
ZLIB:   [b 1M] bytes 125179 ->  48897 39.1%  comp  17.9 MB/s  uncomp
242.9 MB/s
etc

and summarizing the before/after zlib uncompress numbers give:

alice29.txt       uncomp MB/s  before  258.2  after  392.4  ratio 1.52
asyoulik.txt      uncomp MB/s  before  242.9  after  346.6  ratio 1.43
fireworks.jpeg    uncomp MB/s  before 1066.7  after 1194.7  ratio 1.12
geo.protodata     uncomp MB/s  before  565.6  after  756.8  ratio 1.34
html              uncomp MB/s  before  492.1  after  698.8  ratio 1.42
html_x_4          uncomp MB/s  before  502.1  after  697.8  ratio 1.39
kppkn.gtb         uncomp MB/s  before  336.4  after  483.6  ratio 1.44
lcet10.txt        uncomp MB/s  before  265.2  after  409.5  ratio 1.54
paper-100k.pdf    uncomp MB/s  before  264.9  after  331.4  ratio 1.25
plrabn12.txt      uncomp MB/s  before  240.9  after  372.5  ratio 1.55
urls.10K          uncomp MB/s  before  280.7  after  381.3  ratio 1.36