### PR TITLE
Fix warnings on OSX

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -31,6 +31,10 @@
 #endif
 #include <fcntl.h>
 
+#if defined(__APPLE__)
+#  include <unistd.h>
+#endif
+
 #ifdef _WIN32
 #  include <stddef.h>
 #endif


### PR DESCRIPTION
On OSX, we see warnings like these (abbreviated):
```
gzread.c: warning: implicit declaration of function 'read' is invalid in C99
gzread.c: warning: implicit declaration of function 'close' is invalid in C99
gzwrite.c: warning: implicit declaration of function 'write' is invalid in C99
```
Including <unistd.h> is needed on (at least) OSX to declare "read", "close", "write", and "lseek".

(Hope this is the right place to contribute patches. Thanks)