### PR TITLE
Add defines to replace magic numbers in inflate fast

### DIFF
--- a/infback.c
+++ b/infback.c
@@ -480,7 +480,8 @@ void FAR *out_desc;
 
         case LEN:
             /* use inflate_fast() if we have enough input and output */
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 if (state->whave < state->wsize)
                     state->whave = state->wsize - left;

--- a/inffast.c
+++ b/inffast.c
@@ -23,8 +23,8 @@
    Entry assumptions:
 
         state->mode == LEN
-        strm->avail_in >= 6
-        strm->avail_out >= 258
+        strm->avail_in >= INFLATE_FAST_MIN_HAVE
+        strm->avail_out >= INFLATE_FAST_MIN_LEFT
         start >= strm->avail_out
         state->bits < 8
 
@@ -80,10 +80,10 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
     /* copy state to local variables */
     state = (struct inflate_state FAR *)strm->state;
     in = strm->next_in;
-    last = in + (strm->avail_in - 5);
+    last = in + (strm->avail_in - (INFLATE_FAST_MIN_HAVE - 1));
     out = strm->next_out;
     beg = out - (start - strm->avail_out);
-    end = out + (strm->avail_out - 257);
+    end = out + (strm->avail_out - (INFLATE_FAST_MIN_LEFT - 1));
 #ifdef INFLATE_STRICT
     dmax = state->dmax;
 #endif
@@ -298,9 +298,12 @@ unsigned start;         /* inflate()'s starting value for strm->avail_out */
     /* update state and return */
     strm->next_in = in;
     strm->next_out = out;
-    strm->avail_in = (unsigned)(in < last ? 5 + (last - in) : 5 - (in - last));
+    strm->avail_in = (unsigned)(in < last ?
+        (INFLATE_FAST_MIN_HAVE - 1) + (last - in) :
+        (INFLATE_FAST_MIN_HAVE - 1) - (in - last));
     strm->avail_out = (unsigned)(out < end ?
-                                 257 + (end - out) : 257 - (out - end));
+        (INFLATE_FAST_MIN_LEFT - 1) + (end - out) :
+        (INFLATE_FAST_MIN_LEFT - 1) - (out - end));
     state->hold = hold;
     state->bits = bits;
     return;

--- a/inffast.h
+++ b/inffast.h
@@ -8,4 +8,19 @@
    subject to change. Applications should only use zlib.h.
  */
 
+
+/* INFLATE_FAST_MIN_LEFT is the minimum number of output bytes that are left,
+   so that we can call inflate_fast safely with only one up front bounds check.
+   One length-distance code pair can copy up to 258 bytes.
+ */
+#define INFLATE_FAST_MIN_LEFT 258
+
+/* INFLATE_FAST_MIN_HAVE is the minimum number of input bytes that we have, so
+   that we can call inflate_fast safely with only one up front bounds check.
+   One length-distance code pair (as two Huffman encoded values of up to 15
+   bits each) plus any additional bits (up to 5 for length and 13 for distance)
+   can require reading up to 48 bits, or 6 bytes.
+ */
+#define INFLATE_FAST_MIN_HAVE 6
+
 void ZLIB_INTERNAL inflate_fast OF((z_streamp strm, unsigned start));

--- a/inflate.c
+++ b/inflate.c
@@ -1042,7 +1042,8 @@ int flush;
         case LEN_:
             state->mode = LEN;
         case LEN:
-            if (have >= 6 && left >= 258) {
+            if (have >= INFLATE_FAST_MIN_HAVE &&
+                left >= INFLATE_FAST_MIN_LEFT) {
                 RESTORE();
                 inflate_fast(strm, out);
                 LOAD();


### PR DESCRIPTION
@Nigeltao has a really great patch over at https://github.com/madler/zlib/pull/292
In that patch, there are two #defines that can be moved out into a separate pull request to make a smaller, easier-to-accept pull request. Nigel granted me permission to make a separate pull request.

The great benefit of this patch is it replaces magic numbers with a clear name. This makes the code easier to understand & maintain.