### PR TITLE
Add continuous integration support for GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@
 /configure.log
 
 .DS_Store
+
+.vs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,55 @@
+sudo: false
+dist: trusty
+language: c
+
+branches:
+  only:
+    - master
+    
+script:
+  - ci/travis/build.sh
+
+compiler:
+# - clang
+  - gcc
+
+os:
+  - linux
+# - osx
+
+env:
+  - CMAKE_BUILD_TYPE=Debug
+  - CMAKE_BUILD_TYPE=RelWithDebInfo
+  - CMAKE_BUILD_TYPE=Release
+  - CONFIGURE=
+
+matrix:
+  include:
+    - os: linux
+      compiler: clang
+      env: 
+        - CMAKE_BUILD_TYPE=debug
+        - CTEST_DASHBOARD=ExperimentalMemCheck
+      addons:
+        apt:
+          packages:
+            - valgrind
+    - os: linux
+      compiler: gcc
+      env:
+        - COMMENT=UBSAN
+        - CMAKE_BUILD_TYPE=debug
+        - CMAKE_C_COMPILER=gcc-7
+        - CFLAGS='-fno-omit-frame-pointer -fsanitize=undefined'
+        - LDFLAGS='-fsanitize=undefined'
+      addons:
+        apt:
+          packages:
+            - g++-7
+          sources:
+            - ubuntu-toolchain-r-test
+
+notifications:
+  email:
+    false
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
-enable_testing()
+if(UNIX)
+    find_program( MEMORYCHECK_COMMAND valgrind )
+    set( MEMORYCHECK_COMMAND_OPTIONS "--trace-children=yes --leak-check=full" )
+endif()
+include(CTest)
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
@@ -167,7 +171,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
 string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
     "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
 
-if(MINGW)
+if(MINGW OR CYGWIN)
     # This gets us DLL resource information when compiling on MinGW.
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)
@@ -181,7 +185,7 @@ if(MINGW)
                             -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
                             -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
-endif(MINGW)
+endif()
 
 add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
@@ -233,6 +237,10 @@ endif()
 add_executable(example test/example.c)
 target_link_libraries(example zlib)
 add_test(example example)
+
+add_executable(infcover test/infcover.c)
+target_link_libraries(infcover zlibstatic)
+add_test(infcover infcover)
 
 add_executable(minigzip test/minigzip.c)
 target_link_libraries(minigzip zlib)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,65 @@
+version: 0.0.{build}-{branch}
+
+shallow_clone: true
+
+branches:
+  only:
+    - master
+
+# this a not a .NET project in all cases - we will build during install phase
+build: false
+
+install:
+  - ci\appveyor\env.bat
+  - ci\appveyor\install.bat
+
+test_script:
+  - ci\appveyor\test.bat
+
+matrix:
+  allow_failures:
+    - MAYFAIL: true
+
+environment:
+  global:
+    # Defaults for all builds, overridden below if needed
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    CMAKE_BUILD_TYPE: Release
+
+  matrix:
+    # Visual Studio 2010
+    - GENERATOR: Visual Studio 10 2010
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2013
+
+    # Visual Studio 2015 Win64 Debug
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CMAKE_BUILD_TYPE: Debug
+
+    # Visual Studio 2015 Win64 RelWithDebInfo
+    - GENERATOR: Visual Studio 14 2015 Win64
+      CMAKE_BUILD_TYPE: RelWithDebInfo
+
+    # Visual Studio 2015 Win64 Release
+    - GENERATOR: Visual Studio 14 2015 Win64
+
+    # Cygwin
+    - ADDPATH: C:\cygwin\bin;
+      WRAPPER: cygwin
+
+    # Cygwin64
+    - ADDPATH: C:\cygwin64\bin;
+      WRAPPER: cygwin64
+
+    # MinGW
+    - ADDPATH: C:\mingw\bin;
+      GENERATOR: MinGW Makefiles
+      WRAPPER: mingw
+
+    # MinGW-w64
+    - ADDPATH: C:\mingw-w64\x86_64-6.3.0-posix-seh-rt_v5-rev1\mingw64\bin;
+      GENERATOR: MinGW Makefiles
+      WRAPPER: mingw64
+
+    # MSYS2
+    - ADDPATH: C:\msys64\usr\bin;
+      GENERATOR: MSYS Makefiles

--- a/ci/appveyor/build.bat
+++ b/ci/appveyor/build.bat
@@ -1,0 +1,20 @@
+@ECHO ON
+SETLOCAL
+::CALL ci\appveyor\env.bat
+
+:: Create the build directory
+MKDIR %BUILDDIR% || EXIT /B
+CD %BUILDDIR%
+
+cmake --version
+
+IF "%WRAPPER:~0,6%" == "cygwin" (
+  :: Run the cygwin cmake build in a cygwin bash shell
+  bash.exe -c "cmake %CYGSRCDIR% %DASHG% -DCMAKE_INSTALL_PREFIX=%CYGINSTDIR%" || EXIT /B
+  bash.exe -c "cmake --build . --target install --config %CMAKE_BUILD_TYPE%"  || EXIT /B
+) ELSE (
+  cmake "%SRCDIR%" %DASHG% -DCMAKE_INSTALL_PREFIX=%INSTDIR% %CMAKE_EXTRA%     || EXIT /B
+  cmake --build . --target install --config %CMAKE_BUILD_TYPE%                || EXIT /B
+)
+
+DIR /S %INSTDIR%

--- a/ci/appveyor/env.bat
+++ b/ci/appveyor/env.bat
@@ -1,0 +1,82 @@
+::
+:: Environment Variables
+::
+:: In:
+::   ADDPATH contains path directories that are prepended to the path (optional)
+::   CMAKE_BUILD_TYPE sets the build configuration (required)
+::   CMAKE_EXTRA is additional parameters to pass to cmake (optional)
+::   GENERATOR is the cmake generator to use (optional)
+::   WRAPPER is the build type wrapper to use (optional) [mingw, cygwin, cygwin64]
+::
+:: Out:
+::   BUILDDIR is the directory to do the build in
+::   INSTDIR  is the directory to put the install target files into
+::   SRCDIR   is the directory containing the project
+::
+::   CYGDIR     is the home of cygwin, whichever flavor is being used
+::   CYGSETUP   is the path to the setup executable for installing things
+::   CYGINSTDIR is INSTDIR translated to cygwin's /cygdrive/... path syntax
+::   CYGSRCDIR  is SRCDIR  translated to cygwin's /cygdrive/... path syntax
+::
+::   DASHG    is the cmake -G"<generator>" argument content
+:: 
+
+@ECHO OFF
+
+SET BUILDDIR=C:\temp\build
+SET INSTDIR=C:\temp\install
+SET SRCDIR=%CD%
+
+IF "%WRAPPER%" == "cygwin" (
+  SET CYGDIR=C:\cygwin
+  SET CYGSETUP=C:\cygwin\setup-x86.exe
+) ELSE IF "%WRAPPER%" == "cygwin64" (
+  SET CYGDIR=C:\cygwin64
+  SET CYGSETUP=C:\cygwin64\setup-x86_64.exe
+)
+
+IF "%WRAPPER:~0,6%" == "cygwin" (
+  :: was using cygpath but it isn't available on all cygwin versions, so...
+  SET CYGSRCDIR=/cygdrive/c/projects/zlib
+  SET CYGINSTDIR=/cygdrive/c/temp/install
+)
+
+IF DEFINED GENERATOR (
+  SET DASHG="-G%GENERATOR%"
+)
+
+SET PATH=%ADDPATH%%PATH%
+
+@ECHO/
+@ECHO --------------------------------------------------------------------------------
+@ECHO -- Environment Variables
+@ECHO --------------------------------------------------------------------------------
+@ECHO/
+@ECHO Inputs:
+@ECHO/
+@ECHO ADDPATH          %ADDPATH%
+@ECHO CMAKE_BUILD_TYPE %CMAKE_BUILD_TYPE%
+@ECHO CMAKE_EXTRA      %CMAKE_EXTRA%
+@ECHO GENERATOR        %GENERATOR%
+@ECHO WRAPPER          %WRAPPER%
+@ECHO/
+@ECHO Outputs:
+@ECHO/
+@ECHO BUILDDIR         %BUILDDIR%
+@ECHO INSTDIR          %INSTDIR%
+@ECHO SRCDIR           %SRCDIR%
+@ECHO/
+@ECHO DASHG            %DASHG%
+IF "%WRAPPER:~0,6%" == "cygwin" (
+@ECHO/
+@ECHO CYGDIR           %CYGDIR%
+@ECHO CYGSETUP         %CYGSETUP%
+@ECHO CYGSRCDIR        %CYGSRCDIR%
+@ECHO CYGINSTDIR       %CYGINSTDIR%
+)
+@ECHO/
+@ECHO PATH:
+@ECHO/
+@ECHO %PATH%
+@ECHO/
+@ECHO --------------------------------------------------------------------------------

--- a/ci/appveyor/install.bat
+++ b/ci/appveyor/install.bat
@@ -1,0 +1,21 @@
+@ECHO ON
+SETLOCAL
+::CALL ci\appveyor\env.bat
+
+:: Move sh.exe out of the path for MinGW builds to work
+IF "%WRAPPER:~0,5%" == "mingw" (
+  REN "C:\Program Files\Git\usr\bin\sh.exe" "sh.exx"
+)
+
+:: As an added precaution against cmake locating MinGW items
+:: when doing a MinGW-w64 build, we move MinGW out of the way
+IF "%WRAPPER%" == "mingw64" (
+  MOVE C:\MinGW C:\MinGW-Disabled
+)
+
+:: Install missing cygwin packages
+IF "%WRAPPER:~0,6%" == "cygwin" (
+  %CYGSETUP% -B -q -n -N -d -l %CYGDIR%/var/cache/setup -R %CYGDIR% -s http://mirror.rit.edu/cygwin -P cmake make
+)
+
+CALL ci\appveyor\build.bat

--- a/ci/appveyor/test.bat
+++ b/ci/appveyor/test.bat
@@ -1,0 +1,16 @@
+@ECHO ON
+SETLOCAL
+::CALL ci\appveyor\env.bat
+
+CD %BUILDDIR%                            || EXIT /B
+ctest -D ExperimentalTest                || EXIT /B
+
+IF EXIST %CMAKE_BUILD_TYPE% (
+  CD %CMAKE_BUILD_TYPE%                  || EXIT /B
+)
+COPY example.exe example.exe.orig        || EXIT /B
+minigzip -3 example.exe                  || EXIT /B
+minigzip -9 example.exe.gz               || EXIT /B
+minigzip -d example.exe.gz.gz            || EXIT /B
+minigzip -d example.exe.gz               || EXIT /B
+fc /B example.exe example.exe.orig > nul

--- a/ci/travis/build.sh
+++ b/ci/travis/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Environment Variables
+#
+# CMAKE_BUILD_TYPE sets the cmake variable by that name (default if not set: use ./configure)
+# CMAKE_C_COMPILER sets the cmake variable by that name (default if not set: $CC)
+# CTEST_DASHBOARD sets the dashboard suite to run (default if not set: ExperimentalTest)
+# 
+
+set -ex
+
+SRCDIR=`pwd`
+if [[ "${CTEST_BASHBOARD}" == "ExperimentalMemCheck" ]]; then
+    RUNNER=valgrind
+fi
+mkdir /tmp/build
+cd /tmp/build
+
+if [[ ! -z "$CMAKE_BUILD_TYPE" ]]; then
+  cmake $SRCDIR -DCMAKE_INSTALL_PREFIX=/tmp/install \
+                -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE \
+                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER:-$CC}
+  VERBOSE=1 cmake --build . --target install
+  ctest -D ${CTEST_DASHBOARD:-ExperimentalTest}
+  ls -lsR /tmp/install
+else
+  $SRCDIR/configure $CONFIGURE --prefix=/tmp/install
+  make -j2 install
+  make test
+  ls -lsR /tmp/install
+fi
+
+cp libz.a libz.a.orig
+$RUNNER ./minigzip64 -9 libz.a
+$RUNNER ./minigzip64 -d libz.a.gz
+cmp libz.a libz.a.orig

--- a/gzguts.h
+++ b/gzguts.h
@@ -39,7 +39,7 @@
 #  include <io.h>
 #endif
 
-#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32)
 #  define WIDECHAR
 #endif
 


### PR DESCRIPTION
Add continuous integration support for GitHub
pull requests through Travis CI and Appveyor
using cmake to generate and build the project.
The following targets are built:

Travis:
  - gcc (Debug, RelWithDebInfo, and Release)
  - valgrind (Debug)
  - ubsan (Debug)

Appveyor:
  - Visual Studio 2010 (Release)
  - Visual Studio 2015 (Debug, RelWithDebInfo, and Release)
  - Cygwin (Release)
  - Cygwin64 (Release)
  - MinGW (Release)
  - MinGW-w64 (Release)
  - MSYS2 (Release)

This closes #169
This fixes #238

### Build Results ###

From my fork:

Appveyor: https://ci.appveyor.com/project/jeking3/zlib/build/0.0.54-master
Travis: https://travis-ci.org/jeking3/zlib/builds/306802628