### PR TITLE
minizip: Assortment of build/warning fixes (for develop branch)

### DIFF
--- a/contrib/minizip/crypt.h
+++ b/contrib/minizip/crypt.h
@@ -38,6 +38,8 @@ static int decrypt_byte(unsigned long* pkeys, const z_crc_t* pcrc_32_tab)
                      * unpredictable manner on 16-bit systems; not a problem
                      * with any known compiler so far, though */
 
+    (void) pcrc_32_tab;
+
     temp = ((unsigned)(*(pkeys+2)) & 0xffff) | 2;
     return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
 }

--- a/contrib/minizip/ioapi.c
+++ b/contrib/minizip/ioapi.c
@@ -96,6 +96,9 @@ static voidpf ZCALLBACK fopen_file_func (voidpf opaque, const char* filename, in
 {
     FILE* file = NULL;
     const char* mode_fopen = NULL;
+
+    (void) opaque;
+
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
         mode_fopen = "rb";
     else
@@ -114,6 +117,9 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, 
 {
     FILE* file = NULL;
     const char* mode_fopen = NULL;
+
+    (void) opaque;
+
     if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
         mode_fopen = "rb";
     else
@@ -132,6 +138,9 @@ static voidpf ZCALLBACK fopen64_file_func (voidpf opaque, const void* filename, 
 static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf, uLong size)
 {
     uLong ret;
+
+    (void) opaque;
+
     ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
@@ -139,6 +148,9 @@ static uLong ZCALLBACK fread_file_func (voidpf opaque, voidpf stream, void* buf,
 static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const void* buf, uLong size)
 {
     uLong ret;
+
+    (void) opaque;
+
     ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
     return ret;
 }
@@ -146,6 +158,9 @@ static uLong ZCALLBACK fwrite_file_func (voidpf opaque, voidpf stream, const voi
 static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 {
     long ret;
+
+    (void) opaque;
+
     ret = ftell((FILE *)stream);
     return ret;
 }
@@ -154,14 +169,20 @@ static long ZCALLBACK ftell_file_func (voidpf opaque, voidpf stream)
 static ZPOS64_T ZCALLBACK ftell64_file_func (voidpf opaque, voidpf stream)
 {
     ZPOS64_T ret;
+
+    (void) opaque;
+
     ret = FTELLO_FUNC((FILE *)stream);
     return ret;
 }
 
 static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offset, int origin)
 {
-    int fseek_origin=0;
+    int fseek_origin;
     long ret;
+
+    (void) opaque;
+
     switch (origin)
     {
     case ZLIB_FILEFUNC_SEEK_CUR :
@@ -183,8 +204,11 @@ static long ZCALLBACK fseek_file_func (voidpf  opaque, voidpf stream, uLong offs
 
 static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T offset, int origin)
 {
-    int fseek_origin=0;
+    int fseek_origin;
     long ret;
+
+    (void) opaque;
+
     switch (origin)
     {
     case ZLIB_FILEFUNC_SEEK_CUR :
@@ -210,6 +234,9 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
 static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 {
     int ret;
+
+    (void) opaque;
+
     ret = fclose((FILE *)stream);
     return ret;
 }
@@ -217,12 +244,14 @@ static int ZCALLBACK fclose_file_func (voidpf opaque, voidpf stream)
 static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
 {
     int ret;
+
+    (void) opaque;
+
     ret = ferror((FILE *)stream);
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;

--- a/contrib/minizip/ioapi.h
+++ b/contrib/minizip/ioapi.h
@@ -35,8 +35,8 @@
         #ifndef _LARGEFILE64_SOURCE
                 #define _LARGEFILE64_SOURCE
         #endif
-        #ifndef _FILE_OFFSET_BIT
-                #define _FILE_OFFSET_BIT 64
+        #ifndef _FILE_OFFSET_BITS
+                #define _FILE_OFFSET_BITS 64
         #endif
 
 #endif


### PR DESCRIPTION
* also use `TRYFREE()` instead of `free()` to help builds that wish to use their own `malloc()`/`free()` functions