### PR TITLE
fix broken deflateParams

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -597,10 +597,11 @@ int ZEXPORT deflateParams(strm, level, strategy)
     }
     if (s->level != level) {
         if (s->level == 0 && s->matches != 0) {
-            if (s->matches == 1)
+            if (s->matches == 1) {
                 slide_hash(s);
-            else
+            } else {
                 CLEAR_HASH(s);
+            }
             s->matches = 0;
         }
         s->level = level;


### PR DESCRIPTION
deflateParams is broken with matches != 0. It always
clears the full hash, not only with matches != 1.
The macro expansion of CLEAR_HASH has 2 stmts!

Detected by Coverity: Nesting level does not match indentation
Code that is meant to be executed conditionally may be executed unconditionally

In deflateParams: The indentation of this code suggests it is nested when it
is not.  (CWE-483)