### PR TITLE
patch to correct linker order

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -28,6 +28,7 @@ SFLAGS=-O
 LDFLAGS=
 TEST_LDFLAGS=-L. libz.a
 LDSHARED=$(CC)
+LDSHAREDFLAGS=-shared
 CPP=$(CC) -E
 
 STATICLIB=libz.a
@@ -279,7 +280,7 @@ gzwrite.lo: $(SRCDIR)gzwrite.c
 
 
 placebo $(SHAREDLIBV): $(PIC_OBJS) libz.a
-	$(LDSHARED) $(SFLAGS) -o $@ $(PIC_OBJS) $(LDSHAREDLIBC) $(LDFLAGS)
+	$(LDSHARED) $(SFLAGS) $(LDFLAGS) $(LDSHAREDFLAGS) -o $@ $(PIC_OBJS) $(LDSHAREDLIBC)
 	rm -f $(SHAREDLIB) $(SHAREDLIBM)
 	ln -s $@ $(SHAREDLIB)
 	ln -s $@ $(SHAREDLIBM)

--- a/configure
+++ b/configure
@@ -69,6 +69,7 @@ fi
 
 # set defaults before processing command line options
 LDCONFIG=${LDCONFIG-"ldconfig"}
+LDSHAREDFLAGS="${LDSHAREDFLAGS--shared}"
 LDSHAREDLIBC="${LDSHAREDLIBC--lc}"
 ARCHS=
 prefix=${prefix-/usr/local}
@@ -208,7 +209,7 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   fi
   case "$uname" in
   Linux* | linux* | GNU | GNU/* | solaris*)
-        LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,${SRCDIR}zlib.map"} ;;
+        LDSHARED=${LDSHARED-"$cc -Wl,-soname,libz.so.1,--version-script,${SRCDIR}zlib.map"} ;;
   *BSD | *bsd* | DragonFly)
         LDSHARED=${LDSHARED-"$cc -shared -Wl,-soname,libz.so.1,--version-script,${SRCDIR}zlib.map"}
         LDCONFIG="ldconfig -m" ;;
@@ -410,7 +411,7 @@ if test $shared -eq 1; then
   echo Checking for shared library support... | tee -a configure.log
   # we must test in two steps (cc then ld), required at least on SunOS 4.x
   if try $CC -w -c $SFLAGS $test.c &&
-     try $LDSHARED $SFLAGS -o $test$shared_ext $test.o; then
+     try $LDSHARED $SFLAGS $LDSHAREDFLAGS -o $test$shared_ext $test.o; then
     echo Building shared library $SHAREDLIBV with $CC. | tee -a configure.log
   elif test -z "$old_cc" -a -z "$old_cflags"; then
     echo No shared library support. | tee -a configure.log
@@ -838,6 +839,7 @@ echo EXE = $EXE >> configure.log
 echo LDCONFIG = $LDCONFIG >> configure.log
 echo LDFLAGS = $LDFLAGS >> configure.log
 echo LDSHARED = $LDSHARED >> configure.log
+echo LDSHAREDFLAGS = $LDSHAREDFLAGS >> configure.log
 echo LDSHAREDLIBC = $LDSHAREDLIBC >> configure.log
 echo OBJC = $OBJC >> configure.log
 echo PIC_OBJC = $PIC_OBJC >> configure.log
@@ -866,6 +868,7 @@ sed < ${SRCDIR}Makefile.in "
 /^SFLAGS *=/s#=.*#=$SFLAGS#
 /^LDFLAGS *=/s#=.*#=$LDFLAGS#
 /^LDSHARED *=/s#=.*#=$LDSHARED#
+/^LDSHAREDFLAGS *=/s#=.*#=$LDSHAREDFLAGS#
 /^CPP *=/s#=.*#=$CPP#
 /^STATICLIB *=/s#=.*#=$STATICLIB#
 /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#
@@ -898,6 +901,7 @@ sed < ${SRCDIR}zlib.pc.in "
 /^CFLAGS *=/s#=.*#=$CFLAGS#
 /^CPP *=/s#=.*#=$CPP#
 /^LDSHARED *=/s#=.*#=$LDSHARED#
+/^LDSHAREDFLAGS *=/s#=.*#=$LDSHAREDFLAGS#
 /^STATICLIB *=/s#=.*#=$STATICLIB#
 /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#
 /^SHAREDLIBV *=/s#=.*#=$SHAREDLIBV#


### PR DESCRIPTION
patch will correct the sequence of -pie and -shared options.  When used together, -pie should be provided to the linker before -shared. If -pie is provided after -shared, the linker throws an error shown below as example.

The patch fixes below pkgs:
 - libz.so
```
/host/powerpc-buildroot-linux-gnu/sysroot/usr/lib/Scrt1.o:(.data+0x4):
 undefined reference to `main'
/host/lib/gcc/powerpc-buildroot-linux-gnu/6.4.0/../../../..
/powerpc-buildroot-linux-gnu/bin/ld: BFD (GNU Binutils) 2.28.1
 assertion fail elf32-ppc.c:8923
collect2: error: ld returned 1 exit status
make[2]: *** [libz.so.1.2.11] Error 1
make[1]: *** [/build/zlib-1.2.11/.stamp_built] Error 2
make: *** [_all] Error 2
```
