### PR TITLE
call CLEAR_HASH macro in curly braces

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -598,9 +598,13 @@ int ZEXPORT deflateParams(strm, level, strategy)
     if (s->level != level) {
         if (s->level == 0 && s->matches != 0) {
             if (s->matches == 1)
-                slide_hash(s);
+            {
+               slide_hash(s);
+            }
             else
-                CLEAR_HASH(s);
+            {
+               CLEAR_HASH(s);
+            }
             s->matches = 0;
         }
         s->level = level;


### PR DESCRIPTION
call CLEAR_HASH macro in curly braces.
Reference #332