### PR TITLE
Fix CMakeLists.txt for Visual Studio and AMD64 option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ if(MSVC)
 			contrib/masmx64/gvmat64.asm
 			contrib/masmx64/inffasx64.asm
 		)
+		LIST(APPEND ZLIB_SRCS contrib/masmx64/inffas8664.c)
     endif()
 
 	if(ZLIB_ASMS)


### PR DESCRIPTION
In trying to use CMake with VS2017 x64 to build with the hand tuned assembler version of inffast.c, I ran into the problem described in https://stackoverflow.com/questions/29505121/cmake-zlib-build-on-windows.

I found the second solution ("You need contrib\masmx64\inffas8664.c included in visual studio project file") to be the most helpful, and modified the CMakeLists.txt file to optionally append that file to the ZLIB_SRCS list if both MSVC and AMD64 are true. This adds inffas8664.c to the zlib and zlibstatic projects, and both build without any errors in all configurations for x64.
