### PR TITLE
Drop DLL base address (fixes #325)

### DIFF
--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -49,7 +49,7 @@ $(IMPLIB): $(SHAREDLIB)
 
 $(SHAREDLIB): $(TOP)/win32/zlib.def $(OBJS) $(OBJA) zlib1.res
 	$(LD) $(LDFLAGS) -def:$(TOP)/win32/zlib.def -dll -implib:$(IMPLIB) \
-	  -out:$@ -base:0x5A4C0000 $(OBJS) $(OBJA) zlib1.res
+	  -out:$@ $(OBJS) $(OBJA) zlib1.res
 	if exist $@.manifest \
 	  mt -nologo -manifest $@.manifest -outputresource:$@;2
 


### PR DESCRIPTION
This breaks ARM64 builds (base addresses below 4GB are not allowed) and has
no real use anymore anyway.