### PR TITLE
Initialize 'check' member in inflateResetKeep()

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -137,6 +137,7 @@ z_streamp strm;
     state->lencode = state->distcode = state->next = state->codes;
     state->sane = 1;
     state->back = -1;
+    state->check = 0;
     Tracev((stderr, "inflate: reset\n"));
     return Z_OK;
 }


### PR DESCRIPTION
This avoids a memory sanitizer warning in adler32_z() where the
input adler is undefined due to a call of
UPDATE(state->check, strm->next_out - out, out) at line 1269 of
inflate.c

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7541
Credit to OSS-Fuzz