### PR TITLE
Fixed VS build issues

### DIFF
--- a/contrib/masmx86/bld_ml32.bat
+++ b/contrib/masmx86/bld_ml32.bat
@@ -1,2 +1,2 @@
-ml /coff /Zi /c /Flmatch686.lst match686.asm
-ml /coff /Zi /c /Flinffas32.lst inffas32.asm
+ml /coff /Zi /safeseh /c /Flmatch686.lst match686.asm
+ml /coff /Zi /safeseh /c /Flinffas32.lst inffas32.asm

--- a/contrib/vstudio/vc14/zlibvc.vcxproj
+++ b/contrib/vstudio/vc14/zlibvc.vcxproj
@@ -394,7 +394,7 @@ bld_ml32.bat</Command>
       <TargetMachine>MachineX64</TargetMachine>
     </Link>
     <PreBuildEvent>
-      <Command>cd ..\..\contrib\masmx64
+      <Command>cd ..\..\masmx64
 bld_ml64.bat</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>


### PR DESCRIPTION
- Fixed path to masmx64 in x64 debug.

- Added /safeseh to ml in order to link the obj files.  Without this change I was seeing link error LNK2026: module unsafe for SAFESEH image.