### PR TITLE
Windows fix

### DIFF
--- a/win32/Makefile.gcc
+++ b/win32/Makefile.gcc
@@ -125,8 +125,16 @@ zlibrc.o: win32/zlib1.rc
 .PHONY: install uninstall clean
 
 install: zlib.h zconf.h $(STATICLIB) $(IMPLIB)
-	@if test -z "$(DESTDIR)$(INCLUDE_PATH)" -o -z "$(DESTDIR)$(LIBRARY_PATH)" -o -z "$(DESTDIR)$(BINARY_PATH)"; then \
-		echo INCLUDE_PATH, LIBRARY_PATH, and BINARY_PATH must be specified; \
+	@if "$(DESTDIR)$(INCLUDE_PATH)" == ""; then \
+		echo INCLUDE_PATH must be specified; \
+		exit 1; \
+	fi
+	@if "$(DESTDIR)$(LIBRARY_PATH)" == ""; then \
+		echo LIBRARY_PATH must be specified; \
+		exit 1; \
+	fi
+	@if "$(DESTDIR)$(BINARY_PATH)" == ""; then \
+		echo BINARY_PATH must be specified; \
 		exit 1; \
 	fi
 	-@mkdir -p '$(DESTDIR)$(INCLUDE_PATH)'


### PR DESCRIPTION
I'm trying to build `zlib-sys` which is depended on this library. When I'm trying to build it I get an error:

```text
PS C:\Users\Alex\CLionProjects\untitled3> cargo build -vv
       Fresh pkg-config v0.3.11
       Fresh cc v1.0.15
       Fresh libc v0.2.40
   Compiling libz-sys v1.0.18
     Running `C:\Users\Alex\CLionProjects\untitled3\target\debug\build\libz-sys-8b69be095153c22a\build-script-build`
OPT_LEVEL = Some("0")
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
TARGET = Some("x86_64-pc-windows-gnu")
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
CC_x86_64-pc-windows-gnu = None
CC_x86_64_pc_windows_gnu = None
HOST_CC = None
CC = None
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
CFLAGS_x86_64-pc-windows-gnu = None
CFLAGS_x86_64_pc_windows_gnu = None
HOST_CFLAGS = None
CFLAGS = None
DEBUG = Some("true")
running: "make" "-f" "win32/Makefile.gcc" "install" "prefix=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out" "IMPLIB=" "INCLUDE_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/include" "LIBRARY_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/lib" "BINARY_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/bin"
-z was unexpected at this time.
make: *** [win32/Makefile.gcc:128: install] Error 255


command did not execute successfully, got: exit code: 2


error: failed to run custom build command for `libz-sys v1.0.18`
process didn't exit successfully: `C:\Users\Alex\CLionProjects\untitled3\target\debug\build\libz-sys-8b69be095153c22a\build-script-build` (exit code: 1)
--- stdout
OPT_LEVEL = Some("0")
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
TARGET = Some("x86_64-pc-windows-gnu")
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
CC_x86_64-pc-windows-gnu = None
CC_x86_64_pc_windows_gnu = None
HOST_CC = None
CC = None
TARGET = Some("x86_64-pc-windows-gnu")
HOST = Some("x86_64-pc-windows-gnu")
CFLAGS_x86_64-pc-windows-gnu = None
CFLAGS_x86_64_pc_windows_gnu = None
HOST_CFLAGS = None
CFLAGS = None
DEBUG = Some("true")
running: "make" "-f" "win32/Makefile.gcc" "install" "prefix=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out" "IMPLIB=" "INCLUDE_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/include" "LIBRARY_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/lib" "BINARY_PATH=/C/Users/Alex/CLionProjects/untitled3/target/debug/build/libz-sys-20101f4439ca4593/out/bin"


command did not execute successfully, got: exit code: 2



--- stderr
-z was unexpected at this time.
make: *** [win32/Makefile.gcc:128: install] Error 255
```

It happens because of this line:

https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/win32/Makefile.gcc#L128

`test -z` is not a valid batch code as you can check yourself:

![image](https://user-images.githubusercontent.com/11201122/39957063-160df1a6-55f5-11e8-9ef2-51a8585bd371.png)

This is an attempt to fix this issue for Windows.