### PR TITLE
Fix build on latest cygwin64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
 string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
     "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
 
-if(MINGW)
+if(MINGW OR CYGWIN)
     # This gets us DLL resource information when compiling on MinGW.
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)


### PR DESCRIPTION
I wanted to build [DroneCore](https://github.com/dronecore/DroneCore) a new SDK for autonomous PX4 drones inside my up to date cygwin64 (Windows 10) setup. zlib is one of the dependencies of DroneCore and the one that made the build fail.

Looking at the Problem I found:
- cygwin uses GCC windres syntax
- cygwin doesn't have _wopen and hence we omit WIDECHAR
(this problem is already fixed on develop and was skipped by git when I cherry-picked)

As Cygwin should be supported according to the documentation I though I might contribute my findings to the develop branch such that they are available in the next release.

With this pr the build works fine and I checked `./example` has the expected output:
```
zlib version 1.2.11.1-motley = 0x12b1, compile flags = 0xa9
uncompress(): hello, hello!
gzread(): hello, hello!
gzgets() after gzseek:  hello!
inflate(): hello, hello!
large_inflate(): OK
after inflateSync(): hello, hello!
inflate with dictionary: hello, hello!
```

closes #238 #248 #268

FYI @madler @julianoes