### PR TITLE
Add support for CPack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,19 +5,28 @@ project(zlib C)
 
 set(VERSION "1.2.11")
 
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+
 option(ASM686 "Enable building i686 assembly implementation")
 option(AMD64 "Enable building amd64 assembly implementation")
 
-set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
-set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
-set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
-set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+if (UNIX)
+    set(INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+else()
+    set(INSTALL_PREFIX ".")
+endif()
+
+set(INSTALL_BIN_DIR "${INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
+set(INSTALL_LIB_DIR "${INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
+set(INSTALL_INC_DIR "${INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
+set(INSTALL_MAN_DIR "${INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
+set(INSTALL_PKGCONFIG_DIR "${INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
 
 include(CheckTypeSize)
 include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
+include(CPackConfig.cmake)
 enable_testing()
 
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
@@ -214,10 +223,13 @@ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
     install(TARGETS zlib zlibstatic
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
-        LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+        LIBRARY DESTINATION "${INSTALL_LIB_DIR}"
+        COMPONENT libraries)
 endif()
 if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
-    install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
+    install(FILES ${ZLIB_PUBLIC_HDRS}
+            DESTINATION "${INSTALL_INC_DIR}"
+            COMPONENT headers)
 endif()
 if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
     install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")

--- a/CPackConfig.cmake
+++ b/CPackConfig.cmake
@@ -1,0 +1,50 @@
+# For help take a look at:
+# http://www.cmake.org/Wiki/CMake:CPackConfiguration
+
+### general settings
+set(CPACK_PACKAGE_NAME ${PROJECT_NAME})
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A massively spiffy yet delicately unobtrusive compression library.")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_SOURCE_DIR}/README")
+set(CPACK_PACKAGE_VENDOR "zlib.net")
+set(CPACK_PACKAGE_INSTALL_DIRECTORY ${CPACK_PACKAGE_NAME})
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/README")
+
+
+### versions
+set(CPACK_PACKAGE_VERSION "${VERSION}")
+
+
+### source generator
+set(CPACK_SOURCE_GENERATOR "TGZ")
+set(CPACK_SOURCE_IGNORE_FILES "~$;[.]swp$;/[.]svn/;/[.]git/;.gitignore;tags;cscope.*;.ycm_extra_conf.pyc")
+set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+
+if (WIN32)
+    set(CPACK_GENERATOR "ZIP")
+
+    ### nsis generator
+    find_package(NSIS)
+    if (NSIS_MAKE)
+        set(CPACK_GENERATOR "${CPACK_GENERATOR};NSIS")
+        set(CPACK_NSIS_DISPLAY_NAME "zlib")
+        set(CPACK_NSIS_COMPRESSOR "/SOLID zlib")
+        set(CPACK_NSIS_MENU_LINKS "http://zlib.net/" "zlib homepage")
+    endif (NSIS_MAKE)
+endif (WIN32)
+
+set(CPACK_PACKAGE_INSTALL_DIRECTORY "${PROJECT_NAME}")
+
+set(CPACK_PACKAGE_FILE_NAME ${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION})
+
+set(CPACK_COMPONENT_LIBRARIES_DISPLAY_NAME "Libraries")
+set(CPACK_COMPONENT_HEADERS_DISPLAY_NAME "C/C++ Headers")
+set(CPACK_COMPONENT_LIBRARIES_DESCRIPTION
+  "Libraries used to build programs which use zlib")
+set(CPACK_COMPONENT_HEADERS_DESCRIPTION
+  "C/C++ header files for use with zlib")
+set(CPACK_COMPONENT_HEADERS_DEPENDS libraries)
+#set(CPACK_COMPONENT_APPLICATIONS_GROUP "Runtime")
+set(CPACK_COMPONENT_LIBRARIES_GROUP "Development")
+set(CPACK_COMPONENT_HEADERS_GROUP "Development")
+
+include(CPack)

--- a/cmake/modules/FindNSIS.cmake
+++ b/cmake/modules/FindNSIS.cmake
@@ -1,0 +1,54 @@
+# - Try to find NSIS
+# Once done this will define
+#
+#  NSIS_ROOT_PATH - Set this variable to the root installation of NSIS
+#
+# Read-Only variables:
+#
+#  NSIS_FOUND - system has NSIS
+#  NSIS_MAKE - NSIS creator executable
+#
+#=============================================================================
+#  Copyright (c) 2010-2013 Andreas Schneider <asn@cryptomilk.org>
+#
+#  Distributed under the OSI-approved BSD License (the "License");
+#  see accompanying file Copyright.txt for details.
+#
+#  This software is distributed WITHOUT ANY WARRANTY; without even the
+#  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#  See the License for more information.
+#=============================================================================
+#
+
+if (WIN32)
+    set(_x86 "(x86)")
+
+    set(_NSIS_ROOT_PATHS
+        "$ENV{ProgramFiles}/NSIS"
+        "$ENV{ProgramFiles${_x86}}/NSIS"
+        "[HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\NSIS;Default]")
+
+    find_path(NSIS_ROOT_PATH
+        NAMES
+            Include/Library.nsh
+        PATHS
+            ${_NSIS_ROOT_PATHS}
+        )
+    mark_as_advanced(NSIS_ROOT_PATH)
+endif (WIN32)
+
+find_program(NSIS_MAKE
+    NAMES
+        makensis
+    PATHS
+        ${NSIS_ROOT_PATH}
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(NSIS DEFAULT_MSG NSIS_MAKE)
+
+if (NSIS_MAKE)
+    set(NSIS_FOUND TRUE)
+endif (NSIS_MAKE)
+
+mark_as_advanced(NSIS_MAKE)


### PR DESCRIPTION
This add support for CPack and will offter two targets:

* package_source:
  Generates a source tarball, e.g. zlib-1.2.11.tar.gz

* package:
  Builds a binary package. This is mostly interesting for Windows,
  because if you have NSIS installed it will create a NSIS installer.