### PR TITLE
split statement in two to avoid subtract overflow

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -553,7 +553,8 @@ local void gen_bitlen(s, desc)
             if (m > max_code) continue;
             if ((unsigned) tree[m].Len != (unsigned) bits) {
                 Tracev((stderr,"code %d bits %d->%d\n", m, tree[m].Len, bits));
-                s->opt_len += ((ulg)bits - tree[m].Len) * tree[m].Freq;
+                s->opt_len += (ulg)bits * tree[m].Freq;
+                s->opt_len -= (ulg)tree[m].Len * tree[m].Freq;
                 tree[m].Len = (ush)bits;
             }
             n--;


### PR DESCRIPTION
When compiling zlib with undefined behaviour sanitizers and fuzzers
see pull request https://github.com/madler/zlib/pull/375
make check fails with:
trees.c:556:28: runtime error: unsigned integer overflow: 167173 + 18446744073709551614 cannot be represented in type 'unsigned long'
trees.c:556:28: runtime error: unsigned integer overflow: 167178 + 18446744073709551614 cannot be represented in type 'unsigned long'
trees.c:556:28: runtime error: unsigned integer overflow: 173340 + 18446744073709551614 cannot be represented in type 'unsigned long'
trees.c:556:28: runtime error: unsigned integer overflow: 31612 + 18446744073709551613 cannot be represented in type 'unsigned long'
trees.c:556:42: runtime error: unsigned integer overflow: 6 - 7 cannot be represented in type 'unsigned long'
trees.c:556:57: runtime error: unsigned integer overflow: 18446744073709551615 * 2 cannot be represented in type 'unsigned long'
trees.c:556:57: runtime error: unsigned integer overflow: 18446744073709551615 * 3 cannot be represented in type 'unsigned long'

The patch splits the subtract in two consecutive operations to avoid the
unsigned integer overflow. This change fixes all the errors at trees.c:556.

Patch from Mika Lindqvist.