### PR TITLE
move decrement of induction variable in loop to avoid undefined behavior

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -89,7 +89,8 @@ uLong ZEXPORT adler32_z(adler, buf, len)
 
     /* in case short lengths are provided, keep it somewhat fast */
     if (len < 16) {
-        while (len--) {
+        while (len) {
+            --len;
             adler += *buf++;
             sum2 += adler;
         }
@@ -118,7 +119,8 @@ uLong ZEXPORT adler32_z(adler, buf, len)
             DO16(buf);
             buf += 16;
         }
-        while (len--) {
+        while (len) {
+            --len;
             adler += *buf++;
             sum2 += adler;
         }

--- a/inflate.c
+++ b/inflate.c
@@ -999,8 +999,10 @@ int flush;
                         state->mode = BAD;
                         break;
                     }
-                    while (copy--)
+                    while (copy) {
+                        --copy;
                         state->lens[state->have++] = (unsigned short)len;
+                    }
                 }
             }
 


### PR DESCRIPTION
When compiling zlib with undefined behaviour sanitizers and fuzzers
see pull request https://github.com/madler/zlib/pull/375
make test fails with:
adler32.c:121:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'z_size_t' (aka 'unsigned long')
adler32.c:92:19: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'z_size_t' (aka 'unsigned long')
inflate.c:1002:32: runtime error: unsigned integer overflow: 0 - 1 cannot be represented in type 'unsigned int'

This patch moves the decrement of the induction variable in the loop to avoid
unsigned integer overflow.