### PR TITLE
do not call memcpy with NULL src pointer

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -870,7 +870,8 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     bi_windup(s);        /* align on byte boundary */
     put_short(s, (ush)stored_len);
     put_short(s, (ush)~stored_len);
-    zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
+    if (stored_len)
+        zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
     s->pending += stored_len;
 #ifdef ZLIB_DEBUG
     s->compressed_len = (s->compressed_len + 3 + 7) & (ulg)~7L;


### PR DESCRIPTION
The error was exposed by the fuzzers with undefined behavior sanitizers:

trees.c:874:42: runtime error: null pointer passed as argument 2, which is declared to never be null
/usr/include/string.h:43:28: note: nonnull attribute specified here
SUMMARY: AddressSanitizer: undefined-behavior trees.c:874:42 in

The problem is that deflate.c:1690 calls
_tr_stored_block(s, (char *)0, 0L, last);
which ends up calling memcpy with the null pointer.

The patch avoids calling memcpy when the number of bytes to be copied is zero.