### PR TITLE
Fix compilation warnings

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -97,7 +97,7 @@ void change_file_date(filename,dosdate,tmu_date)
   SetFileTime(hFile,&ftm,&ftLastAcc,&ftm);
   CloseHandle(hFile);
 #else
-#ifdef unix || __APPLE__
+#if defined(unix) || defined(__APPLE__)
   struct utimbuf ut;
   struct tm newdate;
   newdate.tm_sec = tmu_date.tm_sec;

--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -52,6 +52,9 @@
 #else
 # include <unistd.h>
 # include <utime.h>
+// includes for mkdir()
+#include <sys/stat.h>
+#include <sys/types.h>
 #endif
 
 

--- a/contrib/minizip/minizip.c
+++ b/contrib/minizip/minizip.c
@@ -94,7 +94,7 @@ uLong filetime(f, tmzip, dt)
   return ret;
 }
 #else
-#ifdef unix || __APPLE__
+#if defined(unix) || defined(__APPLE__)
 uLong filetime(f, tmzip, dt)
     char *f;               /* name of file to get info on */
     tm_zip *tmzip;         /* return value: access, modific. and creation times */

--- a/contrib/minizip/minizip.c
+++ b/contrib/minizip/minizip.c
@@ -395,7 +395,7 @@ int main(argc,argv)
                    ((argv[i][1]>='0') || (argv[i][1]<='9'))) &&
                   (strlen(argv[i]) == 2)))
             {
-                FILE * fin;
+                FILE * fin = NULL;
                 int size_read;
                 const char* filenameinzip = argv[i];
                 const char *savefilenameinzip;

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -526,8 +526,8 @@ local ZPOS64_T zip64local_SearchCentralDir(const zlib_filefunc64_32_def* pzlib_f
         break;
       }
 
-      if (uPosFound!=0)
-        break;
+    if (uPosFound!=0)
+      break;
   }
   TRYFREE(buf);
   return uPosFound;


### PR DESCRIPTION
This fixes a couple of compilation warnings in contrib/minizip. See the respective commit message for each fix.