### PR TITLE
oss-fuzz/11360: clear out s->prev buffer to avoid undefined behavior

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -318,6 +318,7 @@ int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 
     s->window = (Bytef *) ZALLOC(strm, s->w_size, 2*sizeof(Byte));
     s->prev   = (Posf *)  ZALLOC(strm, s->w_size, sizeof(Pos));
+    memset(s->prev, 0, s->w_size * sizeof(Pos));
     s->head   = (Posf *)  ZALLOC(strm, s->hash_size, sizeof(Pos));
 
     s->high_water = 0;      /* nothing written to s->window yet */


### PR DESCRIPTION
this patch fixes a use of uninitialized value discovered by one of the fuzzers
of the oss-fuzz project:
https://github.com/google/oss-fuzz/blob/master/projects/zlib/example_dict_fuzzer.c
clang's memory sanitizer fails with:

==1==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5930dd in slide_hash zlib/deflate.c:222:20
    #1 0x589461 in fill_window zlib/deflate.c:1558:13
    #2 0x59828f in deflate_rle zlib/deflate.c:2119:13
    #3 0x590614 in deflate zlib/deflate.c:1045:41
    #4 0x4a2d56 in test_dict_deflate /src/example_dict_fuzzer.c:79:11
    #5 0x4a3e9b in LLVMFuzzerTestOneInput /src/example_dict_fuzzer.c:156:3
    #6 0x4ed04b in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:571:15
    #7 0x4a4ff6 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:280:6
    #8 0x4b5e1a in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:713:9
    #9 0x4a4121 in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #10 0x7f3d7a13b82f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291
    #11 0x41ed08 in _start
  Uninitialized value was created by a heap allocation
    #0 0x45fa10 in malloc /src/llvm/projects/compiler-rt/lib/msan/msan_interceptors.cc:911
    #1 0x586920 in deflateInit2_ zlib/deflate.c:320:27
    #2 0x4a2a24 in test_dict_deflate /src/example_dict_fuzzer.c:61:11
    #3 0x4a3e9b in LLVMFuzzerTestOneInput /src/example_dict_fuzzer.c:156:3
    #4 0x4ed04b in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/libfuzzer/FuzzerLoop.cpp:571:15
    #5 0x4a4ff6 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) /src/libfuzzer/FuzzerDriver.cpp:280:6
    #6 0x4b5e1a in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/libfuzzer/FuzzerDriver.cpp:713:9
    #7 0x4a4121 in main /src/libfuzzer/FuzzerMain.cpp:20:10
    #8 0x7f3d7a13b82f in __libc_start_main /build/glibc-Cl5G7W/glibc-2.23/csu/libc-start.c:291