### PR TITLE
minizip: close filestream on error in zipOpen3()

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -908,6 +908,7 @@ extern zipFile ZEXPORT zipOpen3 (const void *pathname, int append, zipcharpc* gl
         TRYFREE(ziinit.globalcomment);
 #    endif /* !NO_ADDFILEINEXISTINGZIP*/
         TRYFREE(zi);
+        ZCLOSE64(ziinit.z_filefunc, ziinit.filestream);
         return NULL;
     }
     else


### PR DESCRIPTION
As on error with zi ALLOC, ZCLOSE64() should match ZOPEN64() at the beginning of the function.