### PR TITLE
Add OSS-Fuzz coversage

### DIFF
--- a/contrib/README.contrib
+++ b/contrib/README.contrib
@@ -67,6 +67,9 @@ puff/       by Mark Adler <madler@alumni.caltech.edu>
         Small, low memory usage inflate.  Also serves to provide an
         unambiguous description of the deflate format.
 
+tests/      by Chris Blume <cblume@google.com>
+        Build targets for OSS-Fuzz.
+
 testzlib/   by Gilles Vollant <info@winimage.com>
         Example of the use of zlib
 

--- a/contrib/tests/fuzzers/README.md
+++ b/contrib/tests/fuzzers/README.md
@@ -1,0 +1,7 @@
+# OSS-Fuzz targets
+
+Fuzz testing is a way to automate the search for vulnerabilities.
+
+This directory include fuzz targets which can be used by
+[OSS-Fuzz](https://github.com/google/oss-fuzz). This allows OSS-Fuzz's
+infrastructure to make sure zlib is safe for users.

--- a/contrib/tests/fuzzers/deflate_fuzzer.cc
+++ b/contrib/tests/fuzzers/deflate_fuzzer.cc
@@ -1,0 +1,47 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <cassert>
+#include <vector>
+
+#include "third_party/zlib/zlib.h"
+
+static Bytef buffer[256 * 1024] = {0};
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // zlib's deflate requires non-zero input sizes
+  if (!size)
+    return 0;
+
+  // We need to strip the 'const' for zlib.
+  std::vector<unsigned char> input_buffer{data, data+size};
+
+  uLongf buffer_length = static_cast<uLongf>(sizeof(buffer));
+
+  z_stream stream;
+  stream.next_in = input_buffer.data();
+  stream.avail_in = size;
+  stream.total_in = size;
+  stream.next_out = buffer;
+  stream.avail_out = buffer_length;
+  stream.total_out = buffer_length;
+  stream.zalloc = Z_NULL;
+  stream.zfree = Z_NULL;
+
+  if (Z_OK != deflateInit(&stream, Z_DEFAULT_COMPRESSION)) {
+    deflateEnd(&stream);
+    assert(false);
+  }
+
+  auto deflate_result = deflate(&stream, Z_NO_FLUSH);
+  deflateEnd(&stream);
+  if (Z_OK != deflate_result)
+    assert(false);
+
+  return 0;
+}

--- a/contrib/tests/fuzzers/deflate_set_dictionary_fuzzer.cc
+++ b/contrib/tests/fuzzers/deflate_set_dictionary_fuzzer.cc
@@ -1,0 +1,43 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <cassert>
+#include <vector>
+
+#include "third_party/zlib/zlib.h"
+
+static Bytef buffer[256 * 1024] = {0};
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // We need to strip the 'const' for zlib.
+  std::vector<unsigned char> input_buffer{data, data + size};
+
+  uLongf buffer_length = static_cast<uLongf>(sizeof(buffer));
+
+  z_stream stream;
+  stream.next_in = input_buffer.data();
+  stream.avail_in = size;
+  stream.total_in = size;
+  stream.next_out = buffer;
+  stream.avail_out = buffer_length;
+  stream.total_out = buffer_length;
+  stream.zalloc = Z_NULL;
+  stream.zfree = Z_NULL;
+
+  if (Z_OK != deflateInit(&stream, Z_DEFAULT_COMPRESSION)) {
+    deflateEnd(&stream);
+    assert(false);
+  }
+
+  auto deflate_set_dictionary_result =
+      deflateSetDictionary(&stream, data, size);
+  deflateEnd(&stream);
+  if (Z_OK != deflate_set_dictionary_result)
+    assert(false);
+
+  return 0;
+}

--- a/contrib/tests/fuzzers/inflate_fuzzer.cc
+++ b/contrib/tests/fuzzers/inflate_fuzzer.cc
@@ -1,0 +1,41 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <cassert>
+#include <vector>
+
+#include "third_party/zlib/zlib.h"
+
+static Bytef buffer[256 * 1024] = {0};
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  // We need to strip the 'const' for zlib
+  std::vector<unsigned char> input_buffer{data, data+size};
+
+  uLongf buffer_length = static_cast<uLongf>(sizeof(buffer));
+
+  z_stream stream;
+  stream.next_in = input_buffer.data();
+  stream.avail_in = size;
+  stream.total_in = size;
+  stream.next_out = buffer;
+  stream.avail_out = buffer_length;
+  stream.total_out = buffer_length;
+  stream.zalloc = Z_NULL;
+  stream.zfree = Z_NULL;
+
+  if (Z_OK != inflateInit(&stream)) {
+    inflateEnd(&stream);
+    assert(false);
+  }
+
+  inflate(&stream, Z_NO_FLUSH);
+  inflateEnd(&stream);
+
+  return 0;
+}

--- a/contrib/tests/fuzzers/uncompress_fuzzer.cc
+++ b/contrib/tests/fuzzers/uncompress_fuzzer.cc
@@ -1,0 +1,21 @@
+// Copyright 2015 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "third_party/zlib/zlib.h"
+
+static Bytef buffer[256 * 1024] = {0};
+
+// Entry point for LibFuzzer.
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  uLongf buffer_length = static_cast<uLongf>(sizeof(buffer));
+  if (Z_OK !=
+      uncompress(buffer, &buffer_length, data, static_cast<uLong>(size))) {
+    return 0;
+  }
+  return 0;
+}


### PR DESCRIPTION
This commit adds coverage for some of zlib's functionality to be used in
OSS-Fuzz's infrastructure.

This allows OSS-Fuzz to provide safety to zlib and its users.