### PR TITLE
Fix UBSAN warning in trees.c.

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -870,7 +870,9 @@ void ZLIB_INTERNAL _tr_stored_block(s, buf, stored_len, last)
     bi_windup(s);        /* align on byte boundary */
     put_short(s, (ush)stored_len);
     put_short(s, (ush)~stored_len);
-    zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
+    if (stored_len > 0) {
+        zmemcpy(s->pending_buf + s->pending, (Bytef *)buf, stored_len);
+    }
     s->pending += stored_len;
 #ifdef ZLIB_DEBUG
     s->compressed_len = (s->compressed_len + 3 + 7) & (ulg)~7L;


### PR DESCRIPTION
memcpy shouldn't be called with a NULL source pointer, even if zero
length is specified.

Fixes #419

Signed-off-by: Harvey Tuch <htuch@google.com>