### PR TITLE
Get __int64 on VMS (Alpha and IA64, not VAX).

### DIFF
--- a/contrib/minizip/ioapi.h
+++ b/contrib/minizip/ioapi.h
@@ -94,7 +94,10 @@ typedef uint64_t ZPOS64_T;
 /* Maximum unsigned 32-bit value used as placeholder for zip64 */
 #define MAXU32 0xffffffff
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
+/* See https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-c04623066 (C)
+ * See https://support.hpe.com/hpsc/doc/public/display?docId=a00058500en_us   (C++)
+ */
+#if defined(_MSC_VER) || defined(__BORLANDC__) || ((defined(__DECC) || defined(__DECCXX)) && !defined(__osf) && (defined(__alpha) || defined(__ia64) || defined(__IA64))) || defined(__int64)
 typedef unsigned __int64 ZPOS64_T;
 #else
 typedef unsigned long long int ZPOS64_T;


### PR DESCRIPTION
Get __int64 via hypothetical macro.

For VMS, confirmation can be seen here:

See https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-c04623066
See https://support.hpe.com/hpsc/doc/public/display?docId=a00058500en_us

Including the implied refinements to avoid OSF and VAX.

They have long long too, but I *hypothesize*
that __int64 came first -- I don't know.
Microsoft is certainly that way -- supporting both
but __int64 came much earlier.