### PR TITLE
Add crc32_combine_* symbol versioning.

### DIFF
--- a/contrib/vstudio/vc10/zlibvc.def
+++ b/contrib/vstudio/vc10/zlibvc.def
@@ -151,3 +151,7 @@ EXPORTS
         deflateGetDictionary                    @173
         adler32_z                               @174
         crc32_z                                 @175
+; zlib1 v1.2.11.1 added:
+        crc32_combine_gen64                     @176
+        crc32_combine_gen                       @177
+        crc32_combine_op                        @178

--- a/contrib/vstudio/vc11/zlibvc.def
+++ b/contrib/vstudio/vc11/zlibvc.def
@@ -151,3 +151,7 @@ EXPORTS
         deflateGetDictionary                    @173
         adler32_z                               @174
         crc32_z                                 @175
+; zlib1 v1.2.11.1 added:
+        crc32_combine_gen64                     @176
+        crc32_combine_gen                       @177
+        crc32_combine_op                        @178

--- a/contrib/vstudio/vc12/zlibvc.def
+++ b/contrib/vstudio/vc12/zlibvc.def
@@ -151,3 +151,7 @@ EXPORTS
         deflateGetDictionary                    @173
         adler32_z                               @174
         crc32_z                                 @175
+; zlib1 v1.2.11.1 added:
+        crc32_combine_gen64                     @176
+        crc32_combine_gen                       @177
+        crc32_combine_op                        @178

--- a/contrib/vstudio/vc14/zlibvc.def
+++ b/contrib/vstudio/vc14/zlibvc.def
@@ -151,3 +151,7 @@ EXPORTS
         deflateGetDictionary                    @173
         adler32_z                               @174
         crc32_z                                 @175
+; zlib1 v1.2.11.1 added:
+        crc32_combine_gen64                     @176
+        crc32_combine_gen                       @177
+        crc32_combine_op                        @178

--- a/contrib/vstudio/vc9/zlibvc.def
+++ b/contrib/vstudio/vc9/zlibvc.def
@@ -151,3 +151,7 @@ EXPORTS
         deflateGetDictionary                    @173
         adler32_z                               @174
         crc32_z                                 @175
+; zlib1 v1.2.11.1 added:
+        crc32_combine_gen64                     @176
+        crc32_combine_gen                       @177
+        crc32_combine_op                        @178

--- a/os400/bndsrc
+++ b/os400/bndsrc
@@ -116,4 +116,12 @@ STRPGMEXP PGMLVL(*CURRENT) SIGNATURE('ZLIB')
   EXPORT SYMBOL("inflateValidate")
   EXPORT SYMBOL("uncompress2")
 
+/*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*/
+/*   Version 1.2.11.1 additional entry points.                      */
+/*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*/
+
+  EXPORT SYMBOL("crc32_combine_gen64")
+  EXPORT SYMBOL("crc32_combine_gen")
+  EXPORT SYMBOL("crc32_combine_op")
+
 ENDPGMEXP

--- a/win32/zlib.def
+++ b/win32/zlib.def
@@ -76,6 +76,10 @@ EXPORTS
     crc32_z
     adler32_combine
     crc32_combine
+; v1.2.11.1 symbols
+    crc32_combine_gen64
+    crc32_combine_gen
+    crc32_combine_op
 ; various hacks, don't look :)
     deflateInit_
     deflateInit2_

--- a/zconf.h
+++ b/zconf.h
@@ -37,6 +37,9 @@
 #  endif
 #  define crc32                 z_crc32
 #  define crc32_combine         z_crc32_combine
+#  define crc32_combine_gen64   z_crc32_combine_gen64
+#  define crc32_combine_gen     z_crc32_combine_gen
+#  define crc32_combine_op      z_crc32_combine_op
 #  define crc32_combine64       z_crc32_combine64
 #  define crc32_z               z_crc32_z
 #  define deflate               z_deflate

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -39,6 +39,9 @@
 #  endif
 #  define crc32                 z_crc32
 #  define crc32_combine         z_crc32_combine
+#  define crc32_combine_gen64   z_crc32_combine_gen64
+#  define crc32_combine_gen     z_crc32_combine_gen
+#  define crc32_combine_op      z_crc32_combine_op
 #  define crc32_combine64       z_crc32_combine64
 #  define crc32_z               z_crc32_z
 #  define deflate               z_deflate

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -37,6 +37,9 @@
 #  endif
 #  define crc32                 z_crc32
 #  define crc32_combine         z_crc32_combine
+#  define crc32_combine_gen64   z_crc32_combine_gen64
+#  define crc32_combine_gen     z_crc32_combine_gen
+#  define crc32_combine_op      z_crc32_combine_op
 #  define crc32_combine64       z_crc32_combine64
 #  define crc32_z               z_crc32_z
 #  define deflate               z_deflate

--- a/zlib.h
+++ b/zlib.h
@@ -1871,7 +1871,7 @@ ZEXTERN int ZEXPORT gzgetc_ OF((gzFile file));  /* backward compatibility */
 #    define z_gzoffset z_gzoffset64
 #    define z_adler32_combine z_adler32_combine64
 #    define z_crc32_combine z_crc32_combine64
-#    define z_crc32_combine_gen z_crc32_combine64_gen
+#    define z_crc32_combine_gen z_crc32_combine_gen64
 #  else
 #    define gzopen gzopen64
 #    define gzseek gzseek64

--- a/zlib.map
+++ b/zlib.map
@@ -92,3 +92,9 @@ ZLIB_1.2.9 {
     adler32_z;
     crc32_z;
 } ZLIB_1.2.7.1;
+
+ZLIB_1.2.11.1 {
+    crc32_combine_gen64;
+    crc32_combine_gen;
+    crc32_combine_op;
+} ZLIB_1.2.9;


### PR DESCRIPTION
Since
https://github.com/madler/zlib/commit/41d86c73b21191a3fa9ea5f476fc9f1fc5e4f8b3
on devel branch, three new symbols are exported by the library
unversioned. Not sure, if it is intentional to expor them. And if yes,
not sure what is the right version number they should carry.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>