### PR TITLE
inflate returns Z_BUF_ERROR during Z_FINISH when data left to be written

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1270,7 +1270,7 @@ int flush;
     strm->data_type = (int)state->bits + (state->last ? 64 : 0) +
                       (state->mode == TYPE ? 128 : 0) +
                       (state->mode == LEN_ || state->mode == COPY_ ? 256 : 0);
-    if (((in == 0 && out == 0) || flush == Z_FINISH) && ret == Z_OK)
+    if (((in == 0 && out == 0) || (out == 0 && flush == Z_FINISH)) && ret == Z_OK)
         ret = Z_BUF_ERROR;
     return ret;
 }


### PR DESCRIPTION
I think I have run into an issue with _inflate_ using small buffers where the function returns Z_BUF_ERROR when there is no more input, yet there is still output being written. 

Here is what I changed:

```
if (((in == 0 && out == 0) || flush == Z_FINISH) && ret == Z_OK)
    return Z_BUF_ERROR;
```

To

```
if (((in == 0 && out == 0) || (out == 0 && flush == Z_FINISH)) && ret == Z_OK)
    return Z_BUF_ERROR;
```
And it only returns Z_BUF_ERROR now if it is Z_FINISH and nothing was output. 

Here is an example code that reproduces the issue:

```
#include <stdio.h>
#include <zlib.h>
#include <stdint.h>
int test_inflate_buf_err(void)
{
    int err;
    z_stream d_stream; /* decompression stream */
    char *original = "thyqtxgidvhyqt";
    char uncompr[30] = { 0 };
    char compr[13] = { 0x2b, 0xc9, 0xa8, 0x2c, 0x2c, 0xa9, 0x48, 0xcf, 0x4c, 0x29, 0x03, 0x31, 0x00 };

    d_stream.zalloc = zalloc;
    d_stream.zfree = zfree;
    d_stream.opaque = (void *)0;
    d_stream.total_in = 0;
    d_stream.total_out = 0;

    err = inflateInit2(&d_stream, -MAX_WBITS);
    if (err != Z_OK) {
        printf("inflateInit2: error %d\n", err);
        return err;
    }

    d_stream.next_in  = compr;
    d_stream.next_out = uncompr;

    while (d_stream.total_out < sizeof(uncompr) && d_stream.total_in < sizeof(compr)) {
        d_stream.avail_in = d_stream.avail_out = 1; /* force small buffers */
        err = inflate(&d_stream, Z_NO_FLUSH);
        if (err == Z_STREAM_END) break;
        if (err != Z_OK) {
            printf("inflate Z_NO_FLUSH: error %d\n", err);
            return err;
        }
    }

    while (d_stream.total_out < sizeof(uncompr)) {
        d_stream.avail_out = 1;
        err = inflate(&d_stream, Z_FINISH);
        if (err == Z_STREAM_END) break;
        if (err != Z_OK) {
            printf("inflate Z_FINISH: error %d\n", err);
            return err;
        }
    }

    err = inflateEnd(&d_stream);
    if (err != Z_OK) {
        printf("inflateEnd: error %d\n", err);
        return err;
    }

    if (memcmp(original, uncompr, strlen(original)) != 0) {
        printf("inflate bad result");
        return err;
    }

    return Z_OK;
}
```
For the ease of the example code I just put the compressed data inline and original inline. I wrote some code that found the smallest input data that could reproduce the issue.

I have attached two files. This is the compressed data:
[bad_burn.compressed.txt](https://github.com/madler/zlib/files/3581044/bad_burn.compressed.txt)

And this is the original content:
[bad_burn.orginal.txt](https://github.com/madler/zlib/files/3581045/bad_burn.orginal.txt)
