### PR TITLE
Fix #466

### DIFF
--- a/zconf.h
+++ b/zconf.h
@@ -130,6 +130,7 @@
 #    define uncompress2           z_uncompress2
 #  endif
 #  define zError                z_zError
+#  define z_errmsg              z_z_errmsg
 #  ifndef Z_SOLO
 #    define zcalloc               z_zcalloc
 #    define zcfree                z_zcfree

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -132,6 +132,7 @@
 #    define uncompress2           z_uncompress2
 #  endif
 #  define zError                z_zError
+#  define z_errmsg              z_z_errmsg
 #  ifndef Z_SOLO
 #    define zcalloc               z_zcalloc
 #    define zcfree                z_zcfree

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -130,6 +130,7 @@
 #    define uncompress2           z_uncompress2
 #  endif
 #  define zError                z_zError
+#  define z_errmsg              z_z_errmsg
 #  ifndef Z_SOLO
 #    define zcalloc               z_zcalloc
 #    define zcfree                z_zcfree


### PR DESCRIPTION
Building with configure `--zprefix` is a nice feature because it prefixes all exported symbols with `z_`. This allows linking a zlib built in such a way with a program which already uses e default zlib which is nice for experimenting with new versions.

Unfortunately there's one symbol, namely `z_errmsg` which is not prefixed (in this case `z_` is already in the original name), leading to duplicate symbols in the scenario described above.

The fix is trivial - just prefix `z_errmsg` with another `z_` as well in `zconf.{h,h.in,zconf.h.cmakein}`