### PR TITLE
Fix UWP detection in iowin32.c.

### DIFF
--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -26,9 +26,8 @@
 #endif
 
 
-// see Include/shared/winapifamily.h in the Windows Kit
-#if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
-#if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
+#if !defined(IOWIN32_USING_WINRT_API)
+#if defined(WINAPI_FAMILY) && (WINAPI_FAMILY == WINAPI_FAMILY_APP)
 #define IOWIN32_USING_WINRT_API 1
 #endif
 #endif


### PR DESCRIPTION
Use WINAPI_FAMILY instead of WINAPI_FAMILY_PARTITION.

Fixes #480

PTAL @madler 