### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/contrib/vstudio/readme.txt
+++ b/contrib/vstudio/readme.txt
@@ -43,6 +43,17 @@ Build instructions for Visual Studio 2015 (32 bits or 64 bits)
 - Decompress current zlib, including all contrib/* files
 - Open contrib\vstudio\vc14\zlibvc.sln with Microsoft Visual C++ 2015
 
+Install and build instructions via vcpkg
+----------------------------------------
+You can download and install minizip using the vcpkg(https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install minizip
+
+The minizip port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please create an issue or pull request(https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Important
 ---------


### PR DESCRIPTION
`minizip `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for minizip and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build minizip, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.
Note: Currently this port only supports static library linkage as a static build.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/minizip/portfile.cmake). We try to keep the library maintained as close as possible to the original library.