### PR TITLE
These are changes to support the Embarcadero C++ clang-based compiler…

### DIFF
--- a/contrib/minizip/ioapi.h
+++ b/contrib/minizip/ioapi.h
@@ -94,7 +94,7 @@ typedef uint64_t ZPOS64_T;
 /* Maximum unsigned 32-bit value used as placeholder for zip64 */
 #define MAXU32 0xffffffff
 
-#if defined(_MSC_VER) || defined(__BORLANDC__)
+#if defined(_MSC_VER) || defined(__BORLANDC__) && !defined(__clang__)
 typedef unsigned __int64 ZPOS64_T;
 #else
 typedef unsigned long long int ZPOS64_T;

--- a/gzguts.h
+++ b/gzguts.h
@@ -66,7 +66,7 @@
 #  endif
 #endif
 
-#if defined(MSDOS) && defined(__BORLANDC__) && (BORLANDC > 0x410)
+#if defined(MSDOS) && defined(__BORLANDC__) && !defined(__clang__) && (BORLANDC > 0x410)
 #  ifndef HAVE_VSNPRINTF
 #    define HAVE_VSNPRINTF
 #  endif

--- a/gzlib.c
+++ b/gzlib.c
@@ -5,7 +5,7 @@
 
 #include "gzguts.h"
 
-#if defined(_WIN32) && !defined(__BORLANDC__)
+#if defined(_WIN32) && (!defined(__BORLANDC__) || defined(__clang__))
 #  define LSEEK _lseeki64
 #else
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0

--- a/test/example.c
+++ b/test/example.c
@@ -5,7 +5,7 @@
 
 /* @(#) $Id$ */
 
-#include "zlib.h"
+#include "..\zlib.h"
 #include <stdio.h>
 
 #ifdef STDC

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -15,7 +15,7 @@
 
 /* @(#) $Id$ */
 
-#include "zlib.h"
+#include "..\zlib.h"
 #include <stdio.h>
 
 #ifdef STDC

--- a/win32/Makefile.bor_clang_x32
+++ b/win32/Makefile.bor_clang_x32
@@ -1,0 +1,108 @@
+# Makefile for zlib
+# Embarcadero C++ clang-based compiler for Win32 with bcc32 command line switches
+#
+# Usage:
+#  make -f win32/Makefile.bor_clang_x32
+
+# ------------ Borland C++ ------------
+
+# Optional nonstandard preprocessor flags (e.g. -DMAX_MEM_LEVEL=7)
+# should be added to the environment via "set LOCAL_ZLIB=-DFOO" or
+# added to the declaration of LOC here:
+LOC = $(LOCAL_ZLIB)
+
+CC = bcc32c
+AS = bcc32c
+LD = bcc32c
+AR = tlib
+CFLAGS  = -a -d -O2 $(LOC)
+ASFLAGS = $(LOC)
+LDFLAGS = $(LOC)
+
+
+# variables
+ZLIB_LIB = zlib.lib
+
+OBJ1 = adler32.obj compress.obj crc32.obj deflate.obj gzclose.obj gzlib.obj gzread.obj
+OBJ2 = gzwrite.obj infback.obj inffast.obj inflate.obj inftrees.obj trees.obj uncompr.obj zutil.obj
+#OBJA =
+OBJP1 = +adler32.obj+compress.obj+crc32.obj+deflate.obj+gzclose.obj+gzlib.obj+gzread.obj
+OBJP2 = +gzwrite.obj+infback.obj+inffast.obj+inflate.obj+inftrees.obj+trees.obj+uncompr.obj+zutil.obj
+#OBJPA=
+
+
+# targets
+all: $(ZLIB_LIB) example.exe minigzip.exe
+
+.c.obj:
+	$(CC) -c $(CFLAGS) $<
+
+.asm.obj:
+	$(AS) -c $(ASFLAGS) $<
+
+adler32.obj: adler32.c zlib.h zconf.h
+
+compress.obj: compress.c zlib.h zconf.h
+
+crc32.obj: crc32.c zlib.h zconf.h crc32.h
+
+deflate.obj: deflate.c deflate.h zutil.h zlib.h zconf.h
+
+gzclose.obj: gzclose.c zlib.h zconf.h gzguts.h
+
+gzlib.obj: gzlib.c zlib.h zconf.h gzguts.h
+
+gzread.obj: gzread.c zlib.h zconf.h gzguts.h
+
+gzwrite.obj: gzwrite.c zlib.h zconf.h gzguts.h
+
+infback.obj: infback.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inffast.obj: inffast.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h
+
+inflate.obj: inflate.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inftrees.obj: inftrees.c zutil.h zlib.h zconf.h inftrees.h
+
+trees.obj: trees.c zutil.h zlib.h zconf.h deflate.h trees.h
+
+uncompr.obj: uncompr.c zlib.h zconf.h
+
+zutil.obj: zutil.c zutil.h zlib.h zconf.h
+
+example.obj: test/example.c zlib.h zconf.h
+
+minigzip.obj: test/minigzip.c zlib.h zconf.h
+
+
+# For the sake of the old Borland make,
+# the command line is cut to fit in the MS-DOS 128 byte limit:
+$(ZLIB_LIB): $(OBJ1) $(OBJ2)
+	-del $(ZLIB_LIB)
+	$(AR) $(ZLIB_LIB) $(OBJP1)
+	$(AR) $(ZLIB_LIB) $(OBJP2)
+
+
+# testing
+test: example.exe minigzip.exe
+	example
+	echo hello world | minigzip | minigzip -d
+
+example.exe: example.obj $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) example.obj $(ZLIB_LIB)
+
+minigzip.exe: minigzip.obj $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) minigzip.obj $(ZLIB_LIB)
+
+
+# cleanup
+clean:
+	-del $(ZLIB_LIB)
+	-del *.obj
+	-del *.exe
+	-del *.tds
+	-del zlib.bak
+	-del foo.gz

--- a/win32/Makefile.emb_clang_x32
+++ b/win32/Makefile.emb_clang_x32
@@ -1,0 +1,121 @@
+# Makefile for zlib
+# Embarcadero C++ clang-based compiler for Win32 with clang command line switches
+#
+# Usage:
+#  make -f win32/Makefile.emb_clang_x32
+
+# ------------ Embarcadero C++ ------------
+
+# Optional nonstandard preprocessor flags (e.g. -DMAX_MEM_LEVEL=7)
+# should be added to the environment via "set LOCAL_ZLIB=-DFOO" or
+# added to the declaration of LOC here:
+LOC = $(LOCAL_ZLIB)
+
+CC = bcc32x
+AS = tasm32
+LD = bcc32x
+AR = tlib
+
+CBOTH = -m32 -tC -x c -Wall -fpack-struct=1
+CRELEASE = -O2 -Wno-inline -DNDEBUG
+CDEBUG = -O0 -fno-inline -g
+
+# For a debug build change $(CRELEASE) to $(CDEBUG) in the next line
+
+CFLAGS = $(CBOTH) $(CRELEASE) $(LOC)
+ASFLAGS = /ml $(LOC)
+
+LBOTH = -m32 -tC -lS:1048576 -lSc:4098 -lH:1048576 -lHc:8192 -fpack-struct=1
+LRELEASE =
+LDEBUG = -g
+
+# For a debug build change $(LRELEASE) to $(LDEBUG) in the next line
+
+LDFLAGS = $(LBOTH) $(LRELEASE) $(LOC)
+
+# variables
+ZLIB_LIB = zlib.lib
+
+OBJ1 = adler32.obj compress.obj crc32.obj deflate.obj gzclose.obj gzlib.obj gzread.obj
+OBJ2 = gzwrite.obj infback.obj inffast.obj inflate.obj inftrees.obj trees.obj uncompr.obj zutil.obj
+#OBJA =
+OBJP1 = +adler32.obj+compress.obj+crc32.obj+deflate.obj+gzclose.obj+gzlib.obj+gzread.obj
+OBJP2 = +gzwrite.obj+infback.obj+inffast.obj+inflate.obj+inftrees.obj+trees.obj+uncompr.obj+zutil.obj
+#OBJPA=
+
+
+# targets
+all: $(ZLIB_LIB) example.exe minigzip.exe
+
+.c.obj:
+	$(CC) -c $(CFLAGS) $<
+
+.asm.obj:
+	$(AS) $(ASFLAGS) $<
+
+adler32.obj: adler32.c zlib.h zconf.h
+
+compress.obj: compress.c zlib.h zconf.h
+
+crc32.obj: crc32.c zlib.h zconf.h crc32.h
+
+deflate.obj: deflate.c deflate.h zutil.h zlib.h zconf.h
+
+gzclose.obj: gzclose.c zlib.h zconf.h gzguts.h
+
+gzlib.obj: gzlib.c zlib.h zconf.h gzguts.h
+
+gzread.obj: gzread.c zlib.h zconf.h gzguts.h
+
+gzwrite.obj: gzwrite.c zlib.h zconf.h gzguts.h
+
+infback.obj: infback.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inffast.obj: inffast.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h
+
+inflate.obj: inflate.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inftrees.obj: inftrees.c zutil.h zlib.h zconf.h inftrees.h
+
+trees.obj: trees.c zutil.h zlib.h zconf.h deflate.h trees.h
+
+uncompr.obj: uncompr.c zlib.h zconf.h
+
+zutil.obj: zutil.c zutil.h zlib.h zconf.h
+
+example.obj: test/example.c zlib.h zconf.h
+
+minigzip.obj: test/minigzip.c zlib.h zconf.h
+
+
+# For the sake of the old Borland make,
+# the command line is cut to fit in the MS-DOS 128 byte limit:
+$(ZLIB_LIB): $(OBJ1) $(OBJ2)
+	-del $(ZLIB_LIB)
+	$(AR) $(ZLIB_LIB) $(OBJP1)
+	$(AR) $(ZLIB_LIB) $(OBJP2)
+
+
+# testing
+test: example.exe minigzip.exe
+	example
+	echo hello world | minigzip | minigzip -d
+
+example.exe: example.obj $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) example.obj $(ZLIB_LIB)
+
+minigzip.exe: minigzip.obj $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) minigzip.obj $(ZLIB_LIB)
+
+
+# cleanup
+clean:
+	-del $(ZLIB_LIB)
+	-del *.obj
+	-del *.exe
+	-del *.tds
+	-del zlib.bak
+	-del foo.gz

--- a/win32/Makefile.emb_clang_x64
+++ b/win32/Makefile.emb_clang_x64
@@ -1,0 +1,121 @@
+# Makefile for zlib
+# Embarcadero C++ clang-based compiler for Win64
+#
+# Usage:
+#  make -f win32/Makefile.emb_clang_x64
+
+# ------------ Embarcadero C++ ------------
+
+# Optional nonstandard preprocessor flags (e.g. -DMAX_MEM_LEVEL=7)
+# should be added to the environment via "set LOCAL_ZLIB=-DFOO" or
+# added to the declaration of LOC here:
+LOC = $(LOCAL_ZLIB)
+
+CC = bcc64
+AS = nasm
+LD = bcc64
+AR = tlib64
+
+CBOTH = -m64 -tC -x c -Wall -fpack-struct=1
+CRELEASE = -O2 -Wno-inline -DNDEBUG
+CDEBUG = -O0 -fno-inline -g
+
+# For a debug build change $(CRELEASE) to $(CDEBUG) in the next line
+
+CFLAGS = $(CBOTH) $(CRELEASE) $(LOC)
+ASFLAGS = -t -f elf64 $(LOC)
+
+LBOTH = -m64 -tC -lS:1048576 -lSc:4098 -lH:1048576 -lHc:8192 -fpack-struct=1
+LRELEASE =
+LDEBUG = -g
+
+# For a debug build change $(LRELEASE) to $(LDEBUG) in the next line
+
+LDFLAGS = $(LBOTH) $(LRELEASE) $(LOC)
+
+# variables
+ZLIB_LIB = zlib.a
+
+OBJ1 = adler32.o compress.o crc32.o deflate.o gzclose.o gzlib.o gzread.o
+OBJ2 = gzwrite.o infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zutil.o
+#OBJA =
+OBJP1 = +adler32.o+compress.o+crc32.o+deflate.o+gzclose.o+gzlib.o+gzread.o
+OBJP2 = +gzwrite.o+infback.o+inffast.o+inflate.o+inftrees.o+trees.o+uncompr.o+zutil.o
+#OBJPA=
+
+
+# targets
+all: $(ZLIB_LIB) example.exe minigzip.exe
+
+.c.o:
+	$(CC) -c $(CFLAGS) $<
+
+.asm.o:
+	$(AS) $(ASFLAGS) $<
+
+adler32.o: adler32.c zlib.h zconf.h
+
+compress.o: compress.c zlib.h zconf.h
+
+crc32.o: crc32.c zlib.h zconf.h crc32.h
+
+deflate.o: deflate.c deflate.h zutil.h zlib.h zconf.h
+
+gzclose.o: gzclose.c zlib.h zconf.h gzguts.h
+
+gzlib.o: gzlib.c zlib.h zconf.h gzguts.h
+
+gzread.o: gzread.c zlib.h zconf.h gzguts.h
+
+gzwrite.o: gzwrite.c zlib.h zconf.h gzguts.h
+
+infback.o: infback.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inffast.o: inffast.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h
+
+inflate.o: inflate.c zutil.h zlib.h zconf.h inftrees.h inflate.h \
+ inffast.h inffixed.h
+
+inftrees.o: inftrees.c zutil.h zlib.h zconf.h inftrees.h
+
+trees.o: trees.c zutil.h zlib.h zconf.h deflate.h trees.h
+
+uncompr.o: uncompr.c zlib.h zconf.h
+
+zutil.o: zutil.c zutil.h zlib.h zconf.h
+
+example.o: test/example.c zlib.h zconf.h
+
+minigzip.o: test/minigzip.c zlib.h zconf.h
+
+
+# For the sake of the old Borland make,
+# the command line is cut to fit in the MS-DOS 128 byte limit:
+$(ZLIB_LIB): $(OBJ1) $(OBJ2)
+	-del $(ZLIB_LIB)
+	$(AR) $(ZLIB_LIB) $(OBJP1)
+	$(AR) $(ZLIB_LIB) $(OBJP2)
+
+
+# testing
+test: example.exe minigzip.exe
+	example
+	echo hello world | minigzip | minigzip -d
+
+example.exe: example.o $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) example.o $(ZLIB_LIB)
+
+minigzip.exe: minigzip.o $(ZLIB_LIB)
+	$(LD) $(LDFLAGS) minigzip.o $(ZLIB_LIB)
+
+
+# cleanup
+clean:
+	-del $(ZLIB_LIB)
+	-del *.o
+	-del *.exe
+	-del *.tds
+	-del zlib.bak
+	-del foo.gz

--- a/zconf.h
+++ b/zconf.h
@@ -320,7 +320,7 @@
 #  if (defined(__SMALL__) || defined(__MEDIUM__))
      /* Turbo C small or medium model */
 #    define SMALL_MEDIUM
-#    ifdef __BORLANDC__
+#    if defined(__BORLANDC__) && !defined(__clang__)
 #      define FAR _far
 #    else
 #      define FAR far
@@ -333,7 +333,7 @@
     * This is not mandatory, but it offers a little performance increase.
     */
 #  ifdef ZLIB_DLL
-#    if defined(WIN32) && (!defined(__BORLANDC__) || (__BORLANDC__ >= 0x500))
+#    if defined(WIN32) && (!defined(__BORLANDC__) || defined(__clang__) || (__BORLANDC__ >= 0x500))
 #      ifdef ZLIB_INTERNAL
 #        define ZEXTERN extern __declspec(dllexport)
 #      else

--- a/zutil.h
+++ b/zutil.h
@@ -92,7 +92,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #if defined(MSDOS) || (defined(WINDOWS) && !defined(WIN32))
 #  define OS_CODE  0x00
 #  ifndef Z_SOLO
-#    if defined(__TURBOC__) || defined(__BORLANDC__)
+#    if (defined(__TURBOC__) || defined(__BORLANDC__)) && !defined(__clang__)
 #      if (__STDC__ == 1) && (defined(__LARGE__) || defined(__COMPACT__))
          /* Allow compilation with ANSI keywords only enabled */
          void _Cdecl farfree( void *block );
@@ -182,7 +182,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(__BORLANDC__) && !defined(MSDOS)
+#if defined(__BORLANDC__) && !defined(__clang__) && !defined(MSDOS)
   #pragma warn -8004
   #pragma warn -8008
   #pragma warn -8066


### PR DESCRIPTION
…s. The clang-based compilers predefine __clang__ along with the usual __BORLANDC__ to distinguish them from the legacy bcc32 compiler, which only predefines __BORLANDC__. Therefore the clang-based compilers. I have also added makefiles for bcc64, bcc32x, aand bcc32c. The bcc64 compiler is Embarcadero's 64-bit clang-based compiler taking clang command line switches. The bcc32x compiler is Embarcadero's 32-bit compiler taking clang command line switches. The bcc32c compiler is the same as rthe bcc32x compiler but takes bcc32 command line switches.