### PR TITLE
gzguts: xcode12 compile fix

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -24,6 +24,7 @@
 #  include <string.h>
 #  include <stdlib.h>
 #  include <limits.h>
+#  include <unistd.h>
 #endif
 
 #ifndef _POSIX_SOURCE


### PR DESCRIPTION
on xcode12 we need to include `unistd.h` for some functions like `read`,
`write`, `close` etc