### PR TITLE
Make the rename of zconf a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ if(MSVC)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
+option(RENAME_ZCONF "Rename the zconf when building out of source" OFF)
+if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND RENAME_ZCONF)
     # If we're doing an out of source build and the user has a zconf.h
     # in their source tree...
     if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ if(MSVC)
     include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
-option(RENAME_ZCONF "Rename the zconf when building out of source" OFF)
+option(RENAME_ZCONF "Rename the zconf when building out of source" ON)
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR AND RENAME_ZCONF)
     # If we're doing an out of source build and the user has a zconf.h
     # in their source tree...


### PR DESCRIPTION
I at least, found it annoying that the source zconf.h get renamed when I don't need it too.
Especially while using git submodules, and it says that I have made changes that I need to commit, because of the rename.
