### PR TITLE
Fix potential UPDATE macro redefined error in inflate.c

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -445,6 +445,10 @@ unsigned copy;
 
 /* Macros for inflate(): */
 
+/* UPDATE maybe already defined in some distributions, such as VxWorks */
+#ifdef UPDATE
+#  undef UPDATE
+#endif
 /* check function to use adler32() for zlib or crc32() for gzip */
 #ifdef GUNZIP
 #  define UPDATE(check, buf, len) \


### PR DESCRIPTION
UPDATE macro maybe already defined in some distributions, such as VxWorks,
then we get the following compile error:

.../zlib/inflate.c:450:1: "UPDATE" redefined
In file included from .../vxworks-6.4/target/h/sys/types.h:65,
                 from .../zlib/zconf.h:444,
                 from .../zlib/zlib.h:34,
                 from .../zlib/zutil.h:22,
                 from .../zlib/inflate.c:83:
.../vxworks-6.4/target/h/types/vxTypesOld.h:229:1: this is the location
of the previous definition

Let's undefine it to fix this bug.

Signed-off-by: Yanfu Liu <liuyanfu@huawei.com>
Signed-off-by: Junling Zheng <zhengjunling@huawei.com>