### PR TITLE
Option to build zlib against Windows static C runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(VERSION "1.2.11")
 
 option(ASM686 "Enable building i686 assembly implementation")
 option(AMD64 "Enable building amd64 assembly implementation")
+option(ENABLE_STATIC_CRT "Build zlib against the MS LIBCMT[d]")
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
@@ -160,6 +161,15 @@ if(MSVC)
 	if(ZLIB_ASMS)
 		add_definitions(-DASMV -DASMINF)
 	endif()
+endif()
+
+if(ENABLE_STATIC_CRT)
+  foreach(lang C CXX)
+    foreach(suffix "" _DEBUG _MINSIZEREL _RELEASE _RELWITHDEBINFO)
+      set(var "CMAKE_${lang}_FLAGS${suffix}")
+      string(REPLACE "/MD" "/MT" ${var} "${${var}}")
+    endforeach()
+  endforeach()
 endif()
 
 # parse the full version number from zlib.h and include in ZLIB_FULL_VERSION


### PR DESCRIPTION
Adds a new option ENABLE_STATIC_CRT to build zlib against the MS LIBCMT[d],
which does not require msvcrt.dll to be installed. This is used to match up with
static builds of any consuming applications.

This replaces a previous PR, which is losing it's fork.