### PR TITLE
Fix Incorrect block delimitation.

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -599,8 +599,9 @@ int ZEXPORT deflateParams(strm, level, strategy)
         if (s->level == 0 && s->matches != 0) {
             if (s->matches == 1)
                 slide_hash(s);
-            else
+            else {
                 CLEAR_HASH(s);
+            }
             s->matches = 0;
         }
         s->level = level;


### PR DESCRIPTION
Since the complex definition of CLEAR_HASH is used, your code will call zmemzero ((Bytef *) s-> head, (unsigned) (s-> hash_size-1) * sizeof (* s-> head)); regardless of the result of the condition (s-> matches == 1).
I suggest a simple improvement.