### PR TITLE
Fix configure issue #188 for macos i386

### DIFF
--- a/configure
+++ b/configure
@@ -186,6 +186,7 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
   SFLAGS="${CFLAGS--O3} -fPIC"
   if test "$ARCHS"; then
     CFLAGS="${CFLAGS} ${ARCHS}"
+    SFLAGS="${SFLAGS} ${ARCHS}"
     LDFLAGS="${LDFLAGS} ${ARCHS}"
   fi
   if test $build64 -eq 1; then


### PR DESCRIPTION
Apply the architecture flags `$ARCHS` to the shared library compiler flags `$SFLAGS`
This will fix https://github.com/madler/zlib/issues/188