### PR TITLE
Update cmake files to latest CMake.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@
 /configure.log
 
 .DS_Store
+
+.vs/
+.history/
+build/
+CMakeUserPresets.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,149 @@
-cmake_minimum_required(VERSION 2.4.4)
-set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
+cmake_minimum_required(VERSION 3.15)
+if(COMMAND cmake_policy)
+    cmake_policy(SET CMP0048 NEW)
+    cmake_policy(SET CMP0091 NEW)
+endif()
 
-project(zlib C)
+### Why does this need to be MSVC only? ###
+set(CMAKE_DEBUG_POSTFIX "d")
 
-set(VERSION "1.2.11.1")
+# parse the full version number from zlib.h and include in _ZLIB_FULL_VERSION
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/zlib.h" _ZLIB_H)
+string(REGEX REPLACE "^.*#[ \t]*define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*$" "\\1" _ZLIB_FULL_VERSION ${_ZLIB_H})
+unset(_ZLIB_H)
 
-option(ASM686 "Enable building i686 assembly implementation")
-option(AMD64 "Enable building amd64 assembly implementation")
+string(REGEX REPLACE "^([0-9]+)\\.[0-9]+\\.[0-9]+.*$" "\\1" ZLIB_VERSION_MAJOR ${_ZLIB_FULL_VERSION})
+string(REGEX REPLACE "^[0-9]+\\.([0-9]+)\\.[0-9]+.*$" "\\1" ZLIB_VERSION_MINOR ${_ZLIB_FULL_VERSION})
+string(REGEX REPLACE "^[0-9]+\\.[0-9]+\\.([0-9]+).*$" "\\1" ZLIB_VERSION_PATCH ${_ZLIB_FULL_VERSION})
+set(ZLIB_VERSION_STRING "${ZLIB_VERSION_MAJOR}.${ZLIB_VERSION_MINOR}.${ZLIB_VERSION_PATCH}")
 
-set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
-set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
-set(INSTALL_INC_DIR "${CMAKE_INSTALL_PREFIX}/include" CACHE PATH "Installation directory for headers")
-set(INSTALL_MAN_DIR "${CMAKE_INSTALL_PREFIX}/share/man" CACHE PATH "Installation directory for manual pages")
-set(INSTALL_PKGCONFIG_DIR "${CMAKE_INSTALL_PREFIX}/share/pkgconfig" CACHE PATH "Installation directory for pkgconfig (.pc) files")
+set(ZLIB_VERSION_TWEAK "")
+if(_ZLIB_FULL_VERSION MATCHES "^[0-9]+\\.[0-9]+\\.[0-9]+\\.([0-9]+).*$")
+    set(ZLIB_VERSION_TWEAK ${CMAKE_MATCH_1})
+    string(APPEND ZLIB_VERSION_STRING ".${ZLIB_VERSION_TWEAK}")
+endif()
 
+unset(_ZLIB_H)
+
+message(STATUS "Configuring zlib version ${ZLIB_VERSION_STRING}")
+project(zlib VERSION ${ZLIB_VERSION_STRING} LANGUAGES C)
+
+option(ZLIB_NO_SHARED_LIBRARY "Disable building the shared version of zlib" OFF)
+option(ZLIB_NO_STATIC_LIBRARY "Disable building the static version of zlib" OFF)
+option(ZLIB_PREFER_STATIC_LIBRARY "Prefer linking against the static zlib library" OFF)
+
+if(DEFINED BUILD_SHARED_LIBS)
+    if(BUILD_SHARED_LIBS AND ZLIB_NO_SHARED_LIBRARY)
+        message(WARNING "BUILD_SHARED_LIBS is enabled alongside ZLIB_NO_SHARED_LIBRARY")
+        set(ZLIB_NO_SHARED_LIBRARY FALSE CACHE INTERNAL "IGNORED AND DISABLED!")
+    elseif(NOT BUILD_SHARED_LIBS AND ZLIB_NO_STATIC_LIBRARY)
+        message(WARNING "BUILD_SHARED_LIBS is disabled while ZLIB_NO_STATIC_LIBRARY is enabled")
+        set(ZLIB_NO_STATIC_LIBRARY FALSE CACHE INTERNAL "IGNORED AND DISABLED!")
+
+        if(NOT ZLIB_NO_SHARED_LIBRARY)
+            set(ZLIB_PREFER_STATIC_LIBRARY TRUE CACHE INTERNAL "ALWAYS ENABLED!")
+        endif()
+    endif()
+endif()
+
+# End processing if both the shared and static version of zlib are disabled (I mean, who would do this realisiticly?)
+if(ZLIB_NO_SHARED_LIBRARY AND ZLIB_NO_STATIC_LIBRARY)
+    message(FATAL_ERROR "You must either build the shared or static version of zlib!")
+endif()
+
+# Ignore linking against the static version of zlib is the static version is disabled
+if(ZLIB_PREFER_STATIC_LIBRARY AND ZLIB_NO_STATIC_LIBRARY)
+    message(WARNING "Ignoring ZLIB_PREFER_STATIC_LIBRARY because the static zlib library is disabled")
+    unset(ZLIB_PREFER_STATIC_LIBRARY)
+endif()
+
+# Enable the ability to use the static MSVC C runtime if targeting Windows.
+if(WIN32)
+    option(ZLIB_SHARED_USE_STATIC_MSVCRT "Link the shared zlib library against the static MSVC C runtime" OFF)
+    option(ZLIB_STATIC_USE_STATIC_MSVCRT "Link the static zlib library against the static MSVC C runtime" OFF)
+endif()
+
+set(ZLIB_SHARED_NAME "" CACHE STRING "The name of zlib's shared library (Defaults to: z/zlib/zlib1)")
+set(ZLIB_STATIC_NAME "" CACHE STRING "The name of zlib's static library (Defaults to: z/zlibstatic)'")
+
+macro(_ZLIB_NORMALIZE_LIBRARY_NAME lib_link default_name)
+    if("${ZLIB_${lib_lik}_NAME}" STREQUAL "")
+        set(_ZLIB_${lib_link}_NAME "${default_name}" CACHE INTERNAL "")
+    else()
+         set(_ZLIB_${lib_link}_NAME "${ZLIB_${lib_lik}_NAME}" CACHE INTERNAL "")
+    endif()
+endmacro()
+
+_ZLIB_NORMALIZE_LIBRARY_NAME(SHARED "z$<$<NOT:$<BOOL:${UNIX}>>:lib$<$<BOOL:${WIN32}>:1>>")
+_ZLIB_NORMALIZE_LIBRARY_NAME(STATIC "z$<$<NOT:$<BOOL:${UNIX}>>:libstatic>")
+
+option(ZLIB_USE_ZPREFIX "Build zlib with the \"Z_PREFIX\" macro" OFF)
+option(ZLIB_USE_ZSOLO "Build zlib with the \"Z_SOLO\" macro" OFF)
+option(ZLIB_USE_ZCONST "Build zlib with the \"ZLIB_CONST\" macro" OFF)
+### Only allow the ZLIB_WINAPI macro on the Windows platform ###
+if(WIN32)
+    option(ZLIB_USE_WINAPI "Build zlib with the \"ZLIB_WINAPI\" macro" OFF)
+endif()
+
+include(GNUInstallDirs)
+### Hack in GNUInstallDirs compatible variables ###
+_GNUInstallDirs_cache_path_fallback(CMAKE_INSTALL_PKGCONFIGDIR "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig" "pkgconfig (.pc) files")
+_GNUInstallDirs_cache_path_fallback(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake" "CMake (.cmake) files")
+mark_as_advanced(CMAKE_INSTALL_PKGCONFIGDIR CMAKE_INSTALL_CMAKEDIR)
+
+GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_PKGCONFIGDIR CMAKE_INSTALL_PKGCONFIGDIR PKGCONFIG)
+GNUInstallDirs_get_absolute_install_dir(CMAKE_INSTALL_FULL_CMAKEDIR CMAKE_INSTALL_CMAKEDIR CMAKEDIR)
+
+include(CheckIncludeFile)
 include(CheckTypeSize)
 include(CheckFunctionExists)
-include(CheckIncludeFile)
 include(CheckCSourceCompiles)
-enable_testing()
+include(CTest)
 
+check_include_file(stdarg.h      HAVE_STDARG_H)
+### The follow include files are automatically searched for ###
 check_include_file(sys/types.h HAVE_SYS_TYPES_H)
 check_include_file(stdint.h    HAVE_STDINT_H)
 check_include_file(stddef.h    HAVE_STDDEF_H)
+### Check for unistd.h ###
+check_include_file(unistd.h HAVE_UNISTD_H)
 
-#
-# Check to see if we have large file support
-#
-set(CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1)
-# We add these other definitions here because CheckTypeSize.cmake
-# in CMake 2.4.x does not automatically do so and we want
-# compatibility with CMake 2.4.x.
-if(HAVE_SYS_TYPES_H)
-    list(APPEND CMAKE_REQUIRED_DEFINITIONS -DHAVE_SYS_TYPES_H)
-endif()
-if(HAVE_STDINT_H)
-    list(APPEND CMAKE_REQUIRED_DEFINITIONS -DHAVE_STDINT_H)
-endif()
-if(HAVE_STDDEF_H)
-    list(APPEND CMAKE_REQUIRED_DEFINITIONS -DHAVE_STDDEF_H)
-endif()
+### Check for large file support ###
+list(APPEND CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64)
 check_type_size(off64_t OFF64_T)
-if(HAVE_OFF64_T)
-   add_definitions(-D_LARGEFILE64_SOURCE=1)
-endif()
-set(CMAKE_REQUIRED_DEFINITIONS) # clear variable
+list(REMOVE_ITEM CMAKE_REQUIRED_DEFINITIONS -D_LARGEFILE64_SOURCE=1 -D_FILE_OFFSET_BITS=64)
 
-#
-# Check for fseeko
-#
+### Check for fseeko ###
 check_function_exists(fseeko HAVE_FSEEKO)
-if(NOT HAVE_FSEEKO)
-    add_definitions(-DNO_FSEEKO)
+
+# Check if compiler supports GCC's hidden attribute
+check_c_source_compiles(
+    "int __attribute__ (( visibility (\"hidden\") )) get_foo() { return 0; }
+int main() { return get_foo(); }"
+    HAVE_GCC_HIDDEN
+)
+
+macro(_ZLIB_MAP_CONFIG_OPTION option macro)
+    set(${macro} ${${option}} CACHE INTERNAL "zlib C macro \"${macro}\"")
+endmacro()
+
+_ZLIB_MAP_CONFIG_OPTION(ZLIB_USE_ZPREFIX Z_PREFIX)
+_ZLIB_MAP_CONFIG_OPTION(ZLIB_USE_ZSOLO Z_SOLO)
+_ZLIB_MAP_CONFIG_OPTION(ZLIB_USE_ZCONST ZLIB_CONST)
+if(WIN32)
+    _ZLIB_MAP_CONFIG_OPTION(ZLIB_USE_WINAPI ZLIB_WINAPI)
 endif()
 
-#
-# Check for unistd.h
-#
-check_include_file(unistd.h Z_HAVE_UNISTD_H)
+### Configure a list of private compile definitions for zlib ###
+list(APPEND _ZLIB_REQUIRED_DEFINITIONS
+    $<$<NOT:$<BOOL:${HAVE_FSEEKO}>>:NO_FSEEKO>
+    $<$<BOOL:${HAVE_GCC_HIDDEN}>:HAVE_HIDDEN>)
+
+list(APPEND _ZLIB_REQUIRED_PUBLIC_DEFINITIONS
+    $<$<BOOL:${HAVE_OFF64_T}>:_FILE_OFFSET_BITS=64 _LARGEFILE64_SOURCE=1>)
 
 if(MSVC)
-    set(CMAKE_DEBUG_POSTFIX "d")
-    add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
-    add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+    list(APPEND _ZLIB_REQUIRED_DEFINITIONS _CRT_SECURE_NO_DEPRECATE _CRT_NONSTDC_NO_DEPRECATE)
 endif()
 
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
@@ -75,175 +155,178 @@ if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
         message(STATUS "to 'zconf.h.included' because this file is included with zlib")
         message(STATUS "but CMake generates it automatically in the build directory.")
         file(RENAME ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.included)
-  endif()
+    endif()
 endif()
 
-set(ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib.pc)
-configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
-		${ZLIB_PC} @ONLY)
-configure_file(	${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
-		${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
+set(_ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib.pc)
+configure_file(${PROJECT_SOURCE_DIR}/zlib.pc.cmakein ${_ZLIB_PC} @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/zconf.h.cmakein ${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
 
+set(_ZLIB_PUBLIC_HDRS ${CMAKE_CURRENT_BINARY_DIR}/zconf.h zlib.h)
+set(_ZLIB_PRIVATE_HDRS crc32.h deflate.h gzguts.h inffast.h inffixed.h inflate.h inftrees.h trees.h zutil.h)
+set(_ZLIB_SRCS adler32.c crc32.c deflate.c infback.c inffast.c inflate.c inftrees.c trees.c zutil.c
+    compress.c uncompr.c gzclose.c gzlib.c gzread.c gzwrite.c)
 
-#============================================================================
-# zlib
-#============================================================================
+if(NOT ZLIB_NO_SHARED_LIBRARY)
+    if(NOT MINGW)
+        set(_ZLIB_DLL_SRCS win32/zlib1.rc)
+        set_source_files_properties(win32/zlib1.rc PROPERTIES COMPILE_DEFINITIONS ZLIB_DLL_NAME="${_ZLIB_SHARED_NAME}")
+    else()
+        # This gets us DLL resource information when compiling on MinGW.
+        if(NOT CMAKE_RC_COMPILER)
+            find_program(CMAKE_RC_COMPILER windres.exe REQUIRED NO_DEFAULT_PATH NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+        endif()
 
-set(ZLIB_PUBLIC_HDRS
-    ${CMAKE_CURRENT_BINARY_DIR}/zconf.h
-    zlib.h
-)
-set(ZLIB_PRIVATE_HDRS
-    crc32.h
-    deflate.h
-    gzguts.h
-    inffast.h
-    inffixed.h
-    inflate.h
-    inftrees.h
-    trees.h
-    zutil.h
-)
-set(ZLIB_SRCS
-    adler32.c
-    compress.c
-    crc32.c
-    deflate.c
-    gzclose.c
-    gzlib.c
-    gzread.c
-    gzwrite.c
-    inflate.c
-    infback.c
-    inftrees.c
-    inffast.c
-    trees.c
-    uncompr.c
-    zutil.c
-)
-
-if(NOT MINGW)
-    set(ZLIB_DLL_SRCS
-        win32/zlib1.rc # If present will override custom build rule below.
-    )
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+            COMMAND ${CMAKE_RC_COMPILER}
+            -D GCC_WINDRES
+            -D "ZLIB_DLL_NAME=\"${_ZLIB_SHARED_NAME}\""
+            -I ${PROJECT_SOURCE_DIR}
+            -I ${CMAKE_CURRENT_BINARY_DIR}
+            -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
+            -i ${PROJECT_SOURCE_DIR}/win32/zlib1.rc)
+        set(_ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
+    endif()
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCC)
-    if(ASM686)
-        set(ZLIB_ASMS contrib/asm686/match.S)
-    elseif (AMD64)
-        set(ZLIB_ASMS contrib/amd64/amd64-match.S)
-    endif ()
+list(APPEND ZLIB_INCLUDE_DIRS ${CMAKE_CURRENT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 
-	if(ZLIB_ASMS)
-		add_definitions(-DASMV)
-		set_source_files_properties(${ZLIB_ASMS} PROPERTIES LANGUAGE C COMPILE_FLAGS -DNO_UNDERLINE)
-	endif()
-endif()
+macro(_ZLIB_CONFIGURE_TARGET_SHARED target)
+    target_compile_definitions(${target} PRIVATE ${_ZLIB_REQUIRED_DEFINITIONS} PUBLIC ${_ZLIB_REQUIRED_PUBLIC_DEFINITIONS})
+    target_include_directories(${target} PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>)
+    list(APPEND _ZLIB_INSTALL_TARGETS ${target})
+endmacro()
 
-if(MSVC)
-    if(ASM686)
-		ENABLE_LANGUAGE(ASM_MASM)
-        set(ZLIB_ASMS
-			contrib/masmx86/inffas32.asm
-			contrib/masmx86/match686.asm
-		)
-    elseif (AMD64)
-		ENABLE_LANGUAGE(ASM_MASM)
-        set(ZLIB_ASMS
-			contrib/masmx64/gvmat64.asm
-			contrib/masmx64/inffasx64.asm
-		)
+macro(_ZLIB_CREATE_SHARED_LIBRARY name)
+    message(STATUS "Creating shared library ${name}")
+    add_library(${name} SHARED ${_ZLIB_SRCS} ${_ZLIB_DLL_SRCS} ${_ZLIB_PUBLIC_HDRS} ${_ZLIB_PRIVATE_HDRS})
+    target_compile_definitions(${name} PUBLIC ZLIB_DLL)
+    set_target_properties(${name} PROPERTIES
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${ZLIB_SHARED_USE_STATIC_MSVCRT}>>:DLL>"
+        SOVERSION ${PROJECT_VERSION_MAJOR}
+        OUTPUT_NAME "${_ZLIB_SHARED_NAME}")
+    _ZLIB_CONFIGURE_TARGET_SHARED(${name})
+endmacro()
+
+macro(_ZLIB_CREATE_STATIC_LIBRARY name)
+    message(STATUS "Creating static library ${name}")
+    add_library(${name} STATIC ${_ZLIB_SRCS} ${_ZLIB_PUBLIC_HDRS} ${_ZLIB_PRIVATE_HDRS})
+    set_target_properties(${name} PROPERTIES
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>$<$<NOT:$<BOOL:${ZLIB_STATIC_USE_STATIC_MSVCRT}>>:DLL>"
+        OUTPUT_NAME "${_ZLIB_STATIC_NAME}")
+    _ZLIB_CONFIGURE_TARGET_SHARED(${name})
+endmacro()
+
+### While "BUILD_SHARED_LIBS" controls add_library, we'll go with the explicit way ###
+
+if(BUILD_SHARED_LIBS OR NOT ZLIB_NO_SHARED_LIBRARY)
+    _ZLIB_CREATE_SHARED_LIBRARY(zlib)
+    if(NOT ZLIB_NO_STATIC_LIBRARY)
+        _ZLIB_CREATE_STATIC_LIBRARY(zlibstatic)
     endif()
 
-	if(ZLIB_ASMS)
-		add_definitions(-DASMV -DASMINF)
-	endif()
+    list(APPEND ZLIB_LIBRARY "$<TARGET_FILE:zlib>" "$<TARGET_FILE:zlibstatic>")
+    set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
+else()
+    _ZLIB_CREATE_STATIC_LIBRARY(zlib)
+
+    list(APPEND ZLIB_LIBRARY "$<TARGET_FILE:zlib>")
+    set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
 endif()
-
-# parse the full version number from zlib.h and include in ZLIB_FULL_VERSION
-file(READ ${CMAKE_CURRENT_SOURCE_DIR}/zlib.h _zlib_h_contents)
-string(REGEX REPLACE ".*#define[ \t]+ZLIB_VERSION[ \t]+\"([-0-9A-Za-z.]+)\".*"
-    "\\1" ZLIB_FULL_VERSION ${_zlib_h_contents})
-
-if(MINGW)
-    # This gets us DLL resource information when compiling on MinGW.
-    if(NOT CMAKE_RC_COMPILER)
-        set(CMAKE_RC_COMPILER windres.exe)
-    endif()
-
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                       COMMAND ${CMAKE_RC_COMPILER}
-                            -D GCC_WINDRES
-                            -I ${CMAKE_CURRENT_SOURCE_DIR}
-                            -I ${CMAKE_CURRENT_BINARY_DIR}
-                            -o ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                            -i ${CMAKE_CURRENT_SOURCE_DIR}/win32/zlib1.rc)
-    set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
-endif(MINGW)
-
-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
-set_target_properties(zlib PROPERTIES SOVERSION 1)
 
 if(NOT CYGWIN)
     # This property causes shared libraries on Linux to have the full version
     # encoded into their final filename.  We disable this on Cygwin because
-    # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
+    # it causes cygz-${PROJECT_VERSION}.dll to be created when cygz.dll
     # seems to be the default.
     #
     # This has no effect with MSVC, on that platform the version info for
     # the DLL comes from the resource file win32/zlib1.rc
-    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
+    set_target_properties(zlib PROPERTIES VERSION ${PROJECT_VERSION})
+    if(TARGET zlibstatic)
+        set_target_properties(zlibstatic PROPERTIES VERSION ${PROJECT_VERSION})
+    endif()
 endif()
 
-if(UNIX)
-    # On unix-like platforms the library is almost always called libz
-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   if(NOT APPLE)
-     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
-   endif()
-elseif(BUILD_SHARED_LIBS AND WIN32)
-    # Creates zlib1.dll when building shared library version
-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+if(UNIX AND (BUILD_SHARED_LIBS OR NOT ZLIB_NO_SHARED_LIBRARY))
+    if(NOT APPLE)
+        if(NOT "${CMAKE_SYSTEM_NAME}" MATCHES "SunOS")
+            set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${PROJECT_SOURCE_DIR}/zlib.map\"")
+        endif()
+        target_link_libraries(zlib -lc)
+    endif()
 endif()
 
-if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
-    install(TARGETS zlib zlibstatic
-        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
-        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
-        LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
-endif()
-if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
-    install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
-endif()
-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
-    install(FILES zlib.3 DESTINATION "${INSTALL_MAN_DIR}/man3")
-endif()
-if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL )
-    install(FILES ${ZLIB_PC} DESTINATION "${INSTALL_PKGCONFIG_DIR}")
+if(ZLIB_PREFER_STATIC_LIBRARY AND TARGET zlibstatic)
+    add_library(ZLIB::ZLIB ALIAS zlibstatic)
+else()
+    add_library(ZLIB::ZLIB ALIAS zlib)
 endif()
 
-#============================================================================
-# Example binaries
-#============================================================================
+if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL)
+    install(TARGETS ${_ZLIB_INSTALL_TARGETS}
+        EXPORT ZLIBTarget
+        RUNTIME DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}"
+        LIBRARY DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
+    install(EXPORT ZLIBTarget
+        NAMESPACE ZLIB::
+        DESTINATION ${CMAKE_INSTALL_FULL_CMAKEDIR}
+        FILE ZLIBTargets.cmake)
 
-add_executable(example test/example.c)
-target_link_libraries(example zlib)
-add_test(example example)
+    include(CMakePackageConfigHelpers)
 
-add_executable(minigzip test/minigzip.c)
-target_link_libraries(minigzip zlib)
+    write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/ZLIBConfigVersion.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
+    configure_package_config_file(${PROJECT_SOURCE_DIR}/ZLIBConfig.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/ZLIBConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_FULL_CMAKEDIR}
+        NO_SET_AND_CHECK_MACRO
+        NO_CHECK_REQUIRED_COMPONENTS_MACRO
+        PATH_VARS CMAKE_INSTALL_INCLUDEDIR)
 
-if(HAVE_OFF64_T)
-    add_executable(example64 test/example.c)
-    target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ZLIBConfig.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/ZLIBConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_FULL_CMAKEDIR})
+endif()
 
-    add_executable(minigzip64 test/minigzip.c)
-    target_link_libraries(minigzip64 zlib)
-    set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL)
+    install(FILES ${_ZLIB_PUBLIC_HDRS} DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+endif()
+
+if(NOT SKIP_INSTALL_FILES AND NOT SKIP_INSTALL_ALL)
+    install(FILES zlib.3 DESTINATION "${CMAKE_INSTALL_FULL_MANDIR}/man3")
+    install(FILES ${_ZLIB_PC} DESTINATION "${CMAKE_INSTALL_FULL_PKGCONFIGDIR}")
+
+    if(MSVC)
+        install(FILES "$<TARGET_PDB_FILE:zlib>" DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}")
+    endif()
+endif()
+
+unset(_ZLIB_INSTALL_TARGETS)
+set(ZLIB_FOUND TRUE)
+
+if(BUILD_TESTING)
+    add_executable(example test/example.c)
+    target_link_libraries(example ZLIB::ZLIB)
+	target_compile_definitions(example PRIVATE ${_ZLIB_REQUIRED_DEFINITIONS})
+    add_test(example example)
+
+    add_executable(minigzip test/minigzip.c)
+    target_link_libraries(minigzip ZLIB::ZLIB)
+	target_compile_definitions(minigzip PRIVATE ${_ZLIB_REQUIRED_DEFINITIONS})
+
+    if(HAVE_OFF64_T)
+        add_executable(example64 test/example.c)
+        target_link_libraries(example64 ZLIB::ZLIB)
+		target_compile_definitions(example64 PRIVATE ${_ZLIB_REQUIRED_DEFINITIONS} -D_FILE_OFFSET_BITS=64)
+        add_test(example64 example64)
+
+        add_executable(minigzip64 test/minigzip.c)
+        target_link_libraries(minigzip64 ZLIB::ZLIB)
+		target_compile_definitions(minigzip64 PRIVATE ${_ZLIB_REQUIRED_DEFINITIONS} -D_FILE_OFFSET_BITS=64)
+    endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 15,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "configure_common",
+      "hidden": true,
+      "generator": "Ninja",
+      "warnings": {
+        "dev": false,
+        "unusedCli": false,
+        "uninitialized": false,
+        "systemVars": true
+      },
+      "errors": {
+        "deprecated": true
+      }
+    },
+    {
+      "name": "configure_debug",
+      "displayName": "zlib Debug",
+      "description": "Debug build of zlib",
+      "inherits": "configure_common",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        }
+      }
+    },
+    {
+      "name": "configure_release",
+      "displayName": "zlib Release",
+      "description": "Release build of zlib",
+      "inherits": "configure_common",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Release"
+        }
+      }
+    }
+  ]
+}

--- a/ZLIBConfig.cmake.in
+++ b/ZLIBConfig.cmake.in
@@ -1,0 +1,46 @@
+@PACKAGE_INIT@
+
+set(ZLIB_INCLUDE_DIR @PACKAGE_CMAKE_INSTALL_INCLUDEDIR@)
+set(ZLIB_VERSION_MAJOR "@ZLIB_VERSION_MAJOR@")
+set(ZLIB_VERSION_MINOR "@ZLIB_VERSION_MINOR@")
+set(ZLIB_VERSION_PATCH "@ZLIB_VERSION_PATCH@")
+set(ZLIB_VERSION_TWEAK "@ZLIB_VERSION_TWEAK@")
+set(ZLIB_VERSION_STRING "@ZLIB_VERSION_STRING@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/ZLIBTargets.cmake")
+
+### Get the preferred zlib target ###
+if(NOT TARGET ZLIB::zlibstatic OR NOT ZLIB_PREFER_STATIC_LIBRARY)
+	set(_ZLIB_TARGET ZLIB::zlib)
+else()
+	set(_ZLIB_TARGET ZLIB::zlibstatic)
+endif()
+
+### This macro will emulate the "find_library" call in FindZLIB.cmake ###
+macro(_ZLIB_GET_IMPORTED_LIBRARIES)
+	get_target_property(_ZLIB_IMPORTED_CONFIGS ${_ZLIB_TARGET} IMPORTED_CONFIGURATIONS)
+	foreach(_ZLIB_IMPORTED_CONFIG IN LISTS _ZLIB_IMPORTED_CONFIGS)
+		get_target_property(ZLIB_LIBRARY_${_ZLIB_IMPORTED_CONFIG} ${_ZLIB_TARGET} IMPORTED_LOCATION_${_ZLIB_IMPORTED_CONFIG})
+	endforeach()
+	unset(_ZLIB_IMPORTED_CONFIG)
+	unset(_ZLIB_IMPORTED_CONFIGS)
+
+	include(SelectLibraryConfigurations)
+	select_library_configurations(ZLIB)
+endmacro()
+
+_ZLIB_GET_IMPORTED_LIBRARIES()
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(ZLIB REQUIRED_VARS ZLIB_LIBRARY ZLIB_INCLUDE_DIR
+                                       VERSION_VAR ZLIB_VERSION_STRING)
+
+if(ZLIB_FOUND)
+	add_library(ZLIB::ZLIB ALIAS ${_ZLIB_TARGET})
+	set(ZLIB_INCLUDE_DIRS ${ZLIB_INCLUDE_DIR})
+
+	if(NOT ZLIB_LIBRARIES)
+		set(ZLIB_LIBRARIES ${ZLIB_LIBRARY})
+	endif()
+endif()
+unset(_ZLIB_TARGET)

--- a/deflate.h
+++ b/deflate.h
@@ -329,8 +329,8 @@ void ZLIB_INTERNAL _tr_stored_block OF((deflate_state *s, charf *buf,
 # define _tr_tally_dist(s, distance, length, flush) \
   { uch len = (uch)(length); \
     ush dist = (ush)(distance); \
-    s->sym_buf[s->sym_next++] = dist; \
-    s->sym_buf[s->sym_next++] = dist >> 8; \
+    s->sym_buf[s->sym_next++] = (uchf)dist; \
+    s->sym_buf[s->sym_next++] = (uchf)(dist >> 8); \
     s->sym_buf[s->sym_next++] = len; \
     dist--; \
     s->dyn_ltree[_length_code[len]+LITERALS+1].Freq++; \

--- a/win32/zlib1.rc
+++ b/win32/zlib1.rc
@@ -25,9 +25,9 @@ BEGIN
     BEGIN
       VALUE "FileDescription",	"zlib data compression library\0"
       VALUE "FileVersion",	ZLIB_VERSION "\0"
-      VALUE "InternalName",	"zlib1.dll\0"
+      VALUE "InternalName",	ZLIB_DLL_NAME "\0"
       VALUE "LegalCopyright",	"(C) 1995-2017 Jean-loup Gailly & Mark Adler\0"
-      VALUE "OriginalFilename",	"zlib1.dll\0"
+      VALUE "OriginalFilename",	ZLIB_DLL_NAME "\0"
       VALUE "ProductName",	"zlib\0"
       VALUE "ProductVersion",	ZLIB_VERSION "\0"
       VALUE "Comments",		"For more information visit http://www.zlib.net/\0"

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -7,8 +7,9 @@
 
 #ifndef ZCONF_H
 #define ZCONF_H
+
 #cmakedefine Z_PREFIX
-#cmakedefine Z_HAVE_UNISTD_H
+#cmakedefine Z_SOLO
 
 /*
  * If you *really* need a unique prefix for all types and library functions,
@@ -189,6 +190,28 @@
 #  endif
 #endif
 
+#cmakedefine HAVE_STDDEF_H
+#cmakedefine HAVE_STDINT_H
+#cmakedefine HAVE_STDARG_H
+#cmakedefine HAVE_SYS_TYPES_H
+#cmakedefine HAVE_UNISTD_H
+
+#ifdef HAVE_SYS_TYPES_H    /* may be set to #if 1 by ./configure */
+#  define Z_HAVE_SYS_TYPES_H
+#endif
+#ifdef HAVE_STDDEF_H    /* may be set to #if 1 by ./configure */
+#  define Z_HAVE_STDDEF_H
+#endif
+#ifdef HAVE_STDINT_H    /* may be set to #if 1 by ./configure */
+#  define Z_HAVE_STDINT_H
+#endif
+#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
+#  define Z_HAVE_STDARG_H
+#endif
+#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
+#  define Z_HAVE_UNISTD_H
+#endif
+
 /*
  * Compile with -DMAXSEG_64K if the alloc function cannot allocate more
  * than 64k bytes at a time (needed on systems with 16-bit int).
@@ -222,7 +245,6 @@
 #if !defined(STDC) && (defined(OS2) || defined(__HOS_AIX__))
 #  define STDC
 #endif
-
 #if defined(__OS400__) && !defined(STDC)    /* iSeries (formerly AS/400). */
 #  define STDC
 #endif
@@ -233,6 +255,7 @@
 #  endif
 #endif
 
+#cmakedefine ZLIB_CONST
 #if defined(ZLIB_CONST) && !defined(z_const)
 #  define z_const const
 #else
@@ -245,7 +268,7 @@
 #  define z_longlong long long
 #  if defined(NO_SIZE_T)
      typedef unsigned NO_SIZE_T z_size_t;
-#  elif defined(STDC)
+#  elif defined(STDC) || defined(Z_HAVE_STDDEF_H)
 #    include <stddef.h>
      typedef size_t z_size_t;
 #  else
@@ -347,6 +370,7 @@
     * define ZLIB_WINAPI.
     * Caution: the standard ZLIB1.DLL is NOT compiled using ZLIB_WINAPI.
     */
+#  cmakedefine ZLIB_WINAPI
 #  ifdef ZLIB_WINAPI
 #    ifdef FAR
 #      undef FAR
@@ -433,15 +457,7 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
-#  define Z_HAVE_UNISTD_H
-#endif
-
-#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
-#  define Z_HAVE_STDARG_H
-#endif
-
-#ifdef STDC
+#if defined(STDC) || defined(Z_HAVE_SYS_TYPES_H)
 #  ifndef Z_SOLO
 #    include <sys/types.h>      /* for off_t */
 #  endif
@@ -453,7 +469,14 @@ typedef uLong FAR uLongf;
 #  endif
 #endif
 
-#ifdef _WIN32
+#if defined(STDC) || defined(Z_HAVE_STDDEF_H)
+#  ifndef Z_SOLO
+#    include <stddef.h>
+#  endif
+#endif
+
+/* MSVC defined _NATIVE_WCHAR_T_DEFINED when wchar_t is a built-in type like int/long */
+#if !defined(_NATIVE_WCHAR_T_DEFINED) && (defined(WIN32) || defined(Z_HAVE_STDDEF_H))
 #  ifndef Z_SOLO
 #    include <stddef.h>         /* for wchar_t */
 #  endif

--- a/zlib.pc.cmakein
+++ b/zlib.pc.cmakein
@@ -1,12 +1,12 @@
 prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@INSTALL_LIB_DIR@
-sharedlibdir=@INSTALL_LIB_DIR@
-includedir=@INSTALL_INC_DIR@
+exec_prefix=${prefix}
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+sharedlibdir=${libdir}
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: zlib
 Description: zlib compression library
-Version: @VERSION@
+Version: @_ZLIB_FULL_VERSION@
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz


### PR DESCRIPTION
Minimum CMake version is 3.15 (For MSVC_RUNTIME_LIBRARY property)
Added CMake 3.19 CMakePresets.json for quick configuring.

Consumers can create a "CMakeUserPresets.json" to
configure zlib to their desires.


This PR includes content from the following: #310 #337 #343 #395 #471 #500 (Partial) #526