### PR TITLE
fix test execution error when running example and example64 in parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ endif()
 
 add_executable(example test/example.c)
 target_link_libraries(example zlib)
+set_target_properties(example PROPERTIES COMPILE_FLAGS "-DTESTFILE=\\\"foo-gz\\\"")
 add_test(example example)
 
 add_executable(minigzip test/minigzip.c)
@@ -240,7 +241,7 @@ target_link_libraries(minigzip zlib)
 if(HAVE_OFF64_T)
     add_executable(example64 test/example.c)
     target_link_libraries(example64 zlib)
-    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+    set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64 -DTESTFILE=\\\"foo-gz-64\\\"")
     add_test(example64 example64)
 
     add_executable(minigzip64 test/minigzip.c)

--- a/test/example.c
+++ b/test/example.c
@@ -13,12 +13,6 @@
 #  include <stdlib.h>
 #endif
 
-#if defined(VMS) || defined(RISCOS)
-#  define TESTFILE "foo-gz"
-#else
-#  define TESTFILE "foo.gz"
-#endif
-
 #define CHECK_ERR(err, msg) { \
     if (err != Z_OK) { \
         fprintf(stderr, "%s error: %d\n", msg, err); \


### PR DESCRIPTION
When HAVE_OFF64_T is active (almost always I assume) and the tests are run with `ctest -j2` for example, then the testsuite sporadically fails because the test uses the same testfile for both tests (data race on the file).

This change ensures that a different testfile is used for both testcases.