### PR TITLE
Fix compilation error: implicit declaration of function {lseek, read,…

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -37,6 +37,8 @@
 
 #if defined(__TURBOC__) || defined(_MSC_VER) || defined(_WIN32)
 #  include <io.h>
+#else
+#  include <unistd.h>
 #endif
 
 #if defined(_WIN32) || defined(__CYGWIN__)


### PR DESCRIPTION
… write} is invalid in C99.

gzread.c and gzwrite.c use read, write and lseek functions without declaring them
and this is forbidden without the declaration.
The error reproduces on WASI platform, see for the workaround https://phabricator.services.mozilla.com/D116207.