### PR TITLE
slide_hash: add MSAN annotation to suppress known read from uninitialised memory

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -201,6 +201,11 @@ local const config configuration_table[10] = {
  * bit values at the expense of memory usage). We slide even when level == 0 to
  * keep the hash table consistent if we switch back to level > 0 later.
  */
+#if defined(__has_feature)
+#  if __has_feature(memory_sanitizer)
+__attribute__((no_sanitize("memory")))
+#  endif
+#endif
 local void slide_hash(s)
     deflate_state *s;
 {


### PR DESCRIPTION
slide_hash knowingly reads (possibly) uninitialised memory, see comment
lower down about prev[n] potentially being garbage. In this case, the
result is never used - so we don't care about MSAN complaining about
this read.

By adding the no_sanitize("memory") attribute, clients of zlib won't
see this (unnecessary) error when building and running with
MemorySanitizer. An alternative approach is for clients to build zlib
with -fsanitize-ignorelist=... where the ignorelist contains something
like 'fun:slide_hash'. But that's more work and needs to be redone
for any and all CI systems running a given project with MSAN. Adding
this annotation to zlib's sources is overall more convenient - but
also won't affect non-MSAN builds.

This specific issue was found while running git's test suite, but has
also been reported by other clients, see e.g. #518.