### PR TITLE
Add a null check in case ALLOC fails.

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1963,6 +1963,9 @@ extern int ZEXPORT zipRemoveExtraInfoBlock (char* pData, int* dataLen, short sHe
     return ZIP_PARAMERROR;
 
   pNewHeader = (char*)ALLOC(*dataLen);
+  if (pNewHeader == NULL)
+    return ZIP_INTERNALERROR;
+
   pTmp = pNewHeader;
 
   while(p < (pData + *dataLen))


### PR DESCRIPTION
This PR adds a null check to contrib/minizip, in case ALLOC (malloc) fails (i.e. returns NULL). This would prevent a segfault later when copying bytes to pTmp.
