### PR TITLE
Fix potential overflow in `zcalloc`

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -308,7 +308,7 @@ voidpf ZLIB_INTERNAL zcalloc (opaque, items, size)
     unsigned size;
 {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+    return sizeof(uInt) > 2 ? (voidpf)malloc((uInt)items * size) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
Before calling `malloc()`, use a cast to `uInt` so that the multiplication does not overflow.

(This was discovered here: https://lgtm.com/projects/g/madler/zlib/?mode=list)