### PR TITLE
Add option to disable compilation of examples for platforms that are …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(VERSION "1.2.11")
 
 option(ASM686 "Enable building i686 assembly implementation")
 option(AMD64 "Enable building amd64 assembly implementation")
+option(COMPILE_EXAMPLES "Compile the Examples included with zlib" ON)
 
 set(INSTALL_BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin" CACHE PATH "Installation directory for executables")
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib" CACHE PATH "Installation directory for libraries")
@@ -230,6 +231,8 @@ endif()
 # Example binaries
 #============================================================================
 
+if(COMPILE_EXAMPLES) 
+
 add_executable(example test/example.c)
 target_link_libraries(example zlib)
 add_test(example example)
@@ -247,3 +250,5 @@ if(HAVE_OFF64_T)
     target_link_libraries(minigzip64 zlib)
     set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
 endif()
+
+endif(COMPILE_EXAMPLES)


### PR DESCRIPTION
Some embedded platforms such as the PSP do not currently have a full libc implementation and will fail to compile examples giving errors about memcpy / snprintf and various other things.

Ultimately it's ideal that the examples are compiled for testing and the toolchains should be complete i've added an option in CMakeLists.txt to disable the examples if required.
