### PR TITLE
Stop cmake deprecation warning about using minimum versions than 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.4.4)
+cmake_minimum_required(VERSION 2.4.4...3.0)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
 
 project(zlib C)


### PR DESCRIPTION
On Windows using cmake version 3.19.* a deprecation warning about versions less than 2.8.12 was poping up. It seems that early version support will be cut soon. The related change still considers 2.4.4 as the minimum in the minimum range. 