### PR TITLE
Minizip fixes unzip unztell64 invalid for fiel beyond 4GB

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -1857,6 +1857,9 @@ extern int ZEXPORT unzReadCurrentFile  (unzFile file, voidp buf, unsigned len)
               err = Z_DATA_ERROR;
 
             uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
+            /* Detect overflow, because z_stream.total_out is uLong (32 bits) */
+            if (uTotalOutAfter<uTotalOutBefore)
+                uTotalOutAfter += 1LL << 32; /* Add maximum value of uLong + 1 */
             uOutThis = uTotalOutAfter-uTotalOutBefore;
 
             pfile_in_zip_read_info->total_out_64 = pfile_in_zip_read_info->total_out_64 + uOutThis;


### PR DESCRIPTION
Reported by Daniël Hörchner
The issue is that unztell64() does not return the correct value if the position in the current file (in the ZIP archive) is beyond 4 GB.
The cause is that unzReadCurrentFile() does not account for pfile_in_zip_read_info->stream.total_out at line 1854 of unzip.c wrapping around (it is a 32-bit variable). So, on line 1860 uTotalOutAfter can be *less* than uTotalOutBefore, propagating the wraparound to uOutThis, which in turn is added to pfile_in_zip_read_info->total_out_64. That has the effect of subtracting 4 GB.
The issue can be reproduced with the following steps:
- Zip a 5 GB file.
- Read the file inside the ZIP archive beyond 4 GB, for example in increments of 32 kB.
- Call unztell64() afterwards. For example, after having read the entire file.
- You will see that unztell64() returns a value less than the actual number of decompressed bytes.

