### PR TITLE
Fix CC logic in configure

### DIFF
--- a/configure
+++ b/configure
@@ -174,7 +174,10 @@ if test -z "$CC"; then
   else
     cc=${CROSS_PREFIX}cc
   fi
+else
+  cc=${CC}
 fi
+
 cflags=${CFLAGS-"-O3"}
 # to force the asm version use: CFLAGS="-O3 -DASMV" ./configure
 case "$cc" in


### PR DESCRIPTION
In https://github.com/madler/zlib/commit/e9a52aa129efe3834383e415580716a7c4027f8d,
the logic was changed to try check harder for GCC, but it dropped
the default setting of cc=${CC}. It was throwing away any pre-set CC value as
a result.

The rest of the script then cascades down a bad path because it's convinced
it's not GCC or a GCC-like compiler.

This led to e.g. misdetection of inability to build shared libs
for say, multilib cases (w/ CC being one thing from the environment being used
for one test (e.g. x86_64-unknown-linux-gnu-gcc -m32 and then 'cc' used for
shared libs (but missing "-m32"!)). Obviously just one example of how
the old logic could break.

This restores the old default of 'CC' if nothing overrides it later
in configure.

Bug: https://bugs.gentoo.org/836308
Signed-off-by: Sam James <sam@gentoo.org>