### PR TITLE
Fix compile with Windows 10 SDK

### DIFF
--- a/contrib/minizip/iowin32.c
+++ b/contrib/minizip/iowin32.c
@@ -28,6 +28,11 @@
 
 // see Include/shared/winapifamily.h in the Windows Kit
 #if defined(WINAPI_FAMILY_PARTITION) && (!(defined(IOWIN32_USING_WINRT_API)))
+
+#if !defined(WINAPI_FAMILY_ONE_PARTITION)
+#define WINAPI_FAMILY_ONE_PARTITION(PartitionSet, Partition) ((WINAPI_FAMILY & PartitionSet) == Partition)
+#endif
+
 #if WINAPI_FAMILY_ONE_PARTITION(WINAPI_FAMILY, WINAPI_PARTITION_APP)
 #define IOWIN32_USING_WINRT_API 1
 #endif


### PR DESCRIPTION
WINAPI_FAMILY_ONE_PARTITION is not defined in Windows 10/11 - Visual Studio 2022 header.
Without this fix, there is compilation error