### PR TITLE
Use $CC if variable is set

### DIFF
--- a/configure
+++ b/configure
@@ -174,6 +174,8 @@ if test -z "$CC"; then
   else
     cc=${CROSS_PREFIX}cc
   fi
+else
+    cc=${CC}
 fi
 cflags=${CFLAGS-"-O3"}
 # to force the asm version use: CFLAGS="-O3 -DASMV" ./configure


### PR DESCRIPTION
Fixes commit e9a52aa129efe3834383e415580716a7c4027f8d
cc variable is set if CC is not set, and ignored otherwise.

I was unable to build zlib on Linux because $CC was set
To reproduce : 
```
CC=gcc ./configure --shared
make
```

Results :
```
make
/usr/bin/ld: deflate.lo: relocation R_X86_64_PC32 against symbol `_length_code' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:282: libz.so.1.2.12] Error 1
```