### PR TITLE
Extend GZIP conditional

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -401,11 +401,11 @@ local int deflateStateCheck (strm)
     if (s == Z_NULL || s->strm != strm || (s->status != INIT_STATE &&
 #ifdef GZIP
                                            s->status != GZIP_STATE &&
-#endif
                                            s->status != EXTRA_STATE &&
                                            s->status != NAME_STATE &&
                                            s->status != COMMENT_STATE &&
                                            s->status != HCRC_STATE &&
+#endif
                                            s->status != BUSY_STATE &&
                                            s->status != FINISH_STATE))
         return 1;

--- a/deflate.h
+++ b/deflate.h
@@ -54,11 +54,11 @@
 #define INIT_STATE    42    /* zlib header -> BUSY_STATE */
 #ifdef GZIP
 #  define GZIP_STATE  57    /* gzip header -> BUSY_STATE | EXTRA_STATE */
+#  define EXTRA_STATE   69  /* gzip extra block -> NAME_STATE */
+#  define NAME_STATE    73  /* gzip file name -> COMMENT_STATE */
+#  define COMMENT_STATE 91  /* gzip comment -> HCRC_STATE */
+#  define HCRC_STATE   103  /* gzip header CRC -> BUSY_STATE */
 #endif
-#define EXTRA_STATE   69    /* gzip extra block -> NAME_STATE */
-#define NAME_STATE    73    /* gzip file name -> COMMENT_STATE */
-#define COMMENT_STATE 91    /* gzip comment -> HCRC_STATE */
-#define HCRC_STATE   103    /* gzip header CRC -> BUSY_STATE */
 #define BUSY_STATE   113    /* deflate -> FINISH_STATE */
 #define FINISH_STATE 666    /* stream complete */
 /* Stream status */


### PR DESCRIPTION
If gzip support has been disabled during compilation then also
consider gzip relevant states as invalid in deflateStateCheck.

Also the gzip state definitions can be removed.

This change leads to failure in test/example, and I am not sure
what the GZIP conditional is trying to achieve. All gzip related
functions are still defined in zlib.h

Alternative approach is to remove the GZIP define.