### PR TITLE
Address potential buffer overrun issues

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1732,10 +1732,10 @@ local block_state deflate_stored(s, flush)
         _tr_stored_block(s, (char *)0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
-        s->pending_buf[s->pending - 4] = len;
-        s->pending_buf[s->pending - 3] = len >> 8;
-        s->pending_buf[s->pending - 2] = ~len;
-        s->pending_buf[s->pending - 1] = ~len >> 8;
+        s->pending_buf[s->pending - 4] = (Bytef)len;
+        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
+        s->pending_buf[s->pending - 2] = (Bytef)(~len);
+        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
 
         /* Write the stored block header bytes. */
         flush_pending(s->strm);

--- a/gzlib.c
+++ b/gzlib.c
@@ -196,7 +196,11 @@ local gzFile gz_open(path, fd, mode)
     /* save the path name for error messages */
 #ifdef WIDECHAR
     if (fd == -2) {
+#if __STDC_WANT_SECURE_LIB__
         wcstombs_s(&len, NULL, 0, path, 0);
+#else
+        len = wcstombs(NULL, path, 0);
+#endif
         if (len == (z_size_t)-1)
             len = 0;
     }
@@ -211,7 +215,11 @@ local gzFile gz_open(path, fd, mode)
 #ifdef WIDECHAR
     if (fd == -2)
         if (len)
+#if __STDC_WANT_SECURE_LIB__
             wcstombs_s(NULL, state->path, len + 1, path, _TRUNCATE);
+#else
+            wcstombs(state->path, path, len + 1);
+#endif
         else
             *(state->path) = 0;
     else

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -86,9 +86,15 @@ local int gz_comp(state, flush)
     if (state->direct) {
         while (strm->avail_in) {
             put = strm->avail_in > max ? max : strm->avail_in;
-            writ = write(state->fd, strm->next_in, put);
+            writ = _write(state->fd, strm->next_in, put);
             if (writ < 0) {
+#if __STDC_WANT_SECURE_LIB__
+                char error_buf[256];
+                strerror_s(error_buf, sizeof error_buf, errno);
+                gz_error(state, Z_ERRNO, error_buf);
+#else
                 gz_error(state, Z_ERRNO, zstrerror());
+#endif
                 return -1;
             }
             strm->avail_in -= (unsigned)writ;
@@ -116,9 +122,15 @@ local int gz_comp(state, flush)
             while (strm->next_out > state->x.next) {
                 put = strm->next_out - state->x.next > (int)max ? max :
                       (unsigned)(strm->next_out - state->x.next);
-                writ = write(state->fd, state->x.next, put);
+                writ = _write(state->fd, state->x.next, put);
                 if (writ < 0) {
+#if __STDC_WANT_SECURE_LIB__
+                    char error_buf[256];
+                    strerror_s(error_buf, sizeof error_buf, errno);
+                    gz_error(state, Z_ERRNO, error_buf);
+#else
                     gz_error(state, Z_ERRNO, zstrerror());
+#endif
                     return -1;
                 }
                 state->x.next += writ;
@@ -380,7 +392,7 @@ int ZEXPORT gzputs(file, s)
         gz_error(state, Z_STREAM_ERROR, "string length does not fit in int");
         return -1;
     }
-    put = gz_write(state, s, len);
+    put = (int)gz_write(state, s, len);
     return put < len ? -1 : (int)len;
 }
 

--- a/trees.c
+++ b/trees.c
@@ -721,7 +721,7 @@ local void scan_tree (s, tree, max_code)
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq = (ush)(s->bl_tree[curlen].Freq + count);
         } else if (curlen != 0) {
             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
             s->bl_tree[REP_3_6].Freq++;


### PR DESCRIPTION
Changes:
- Use more secure functions (e.g. *_s functions) for Microsoft CRT implementations that support secure libraries. 
- Fixed possible buffer overrun issues by adding a cast when the target variable cannot be truncated.