### PR TITLE
minizip: use default variables/rules in Makefile

### DIFF
--- a/contrib/minizip/Makefile
+++ b/contrib/minizip/Makefile
@@ -1,19 +1,13 @@
-CC=cc
-CFLAGS := $(CFLAGS) -O -I../..
+CPPFLAGS = -I../..
 
 UNZ_OBJS = miniunz.o unzip.o ioapi.o ../../libz.a
 ZIP_OBJS = minizip.o zip.o   ioapi.o ../../libz.a
 
-.c.o:
-	$(CC) -c $(CFLAGS) $*.c
-
 all: miniunz minizip
 
 miniunz:  $(UNZ_OBJS)
-	$(CC) $(CFLAGS) -o $@ $(UNZ_OBJS)
 
 minizip:  $(ZIP_OBJS)
-	$(CC) $(CFLAGS) -o $@ $(ZIP_OBJS)
 
 test:	miniunz minizip
 	@rm -f test.*


### PR DESCRIPTION
The minizip bare Makefile overrides CC/CFLAGS and the default
compile/link rules for no reason, which breaks users who want to pass
specific CFLAGS/LDFLAGS.

These can all be removed: the out-of-box build is unchaged but
overriding CFLAGS or LDFLAGS now works as expected.
