### PR TITLE
fix: Make tests optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,10 +193,8 @@ endif()
 #============================================================================
 # Example binaries
 #============================================================================
-
 add_executable(example test/example.c)
 target_link_libraries(example zlib)
-add_test(example example)
 
 add_executable(minigzip test/minigzip.c)
 target_link_libraries(minigzip zlib)
@@ -205,9 +203,16 @@ if(HAVE_OFF64_T)
     add_executable(example64 test/example.c)
     target_link_libraries(example64 zlib)
     set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
-    add_test(example64 example64)
 
     add_executable(minigzip64 test/minigzip.c)
     target_link_libraries(minigzip64 zlib)
     set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+endif()
+
+if(BUILD_TESTING)
+    add_test(example example)
+
+    if(HAVE_OFF64_T)
+        add_test(example64 example64)
+    endif()
 endif()


### PR DESCRIPTION
When including zlib as a submodule, it is useful to be able to disable the tests.

EXCLUDE_FROM_ALL when including zlib will prevent tests from being automatically built, but cmake will **still attempt to run them**, resulting in something like this from `make test` in the host project:

```
    Start 5: example
Could not find executable example
Looked in the following places:
example
example
Release/example
Release/example
Debug/example
Debug/example
MinSizeRel/example
MinSizeRel/example
RelWithDebInfo/example
RelWithDebInfo/example
Deployment/example
Deployment/example
Development/example
Development/example
Unable to find executable: example
5/6 Test #5: example ..........................***Not Run   0.00 sec
    Start 6: example64
Could not find executable example64
Looked in the following places:
example64
example64
Release/example64
Release/example64
Debug/example64
Debug/example64
MinSizeRel/example64
MinSizeRel/example64
RelWithDebInfo/example64
RelWithDebInfo/example64
Deployment/example64
Deployment/example64
Development/example64
Development/example64
Unable to find executable: example64
6/6 Test #6: example64 ........................***Not Run   0.00 sec

67% tests passed, 2 tests failed out of 6

Total Test time (real) =  23.97 sec

The following tests FAILED:
          5 - example (Not Run)
          6 - example64 (Not Run)
```

This is discussed in https://gitlab.kitware.com/cmake/cmake/-/issues/20212, but after 2 years, there is no obvious consensus on a fix.  So it should be up to the library to be responsible and use the `BUILD_TESTING` variable to guard their calls to add_test().