### PR TITLE
Remove potentially faulty comment

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1898,7 +1898,7 @@ local block_state deflate_fast(s, flush)
             INSERT_STRING(s, s->strstart, hash_head);
         }
 
-        /* Find the longest match, discarding those <= prev_length.
+        /* Find the longest match.
          * At this point we have always match_length < MIN_MATCH
          */
         if (hash_head != NIL && s->strstart - hash_head <= MAX_DIST(s)) {


### PR DESCRIPTION
In function deflate_fast, there seems to be no *discarding those <= prev_length* after calling longest_match. Removing this.