### PR TITLE
 Use NMake batch-rules for compilation

### DIFF
--- a/win32/Makefile.msc
+++ b/win32/Makefile.msc
@@ -69,13 +69,13 @@ minigzip_d.exe: minigzip.obj $(IMPLIB)
 	if exist $@.manifest \
 	  mt -nologo -manifest $@.manifest -outputresource:$@;1
 
-{$(TOP)}.c.obj:
+{$(TOP)}.c.obj::
 	$(CC) -c $(WFLAGS) $(CFLAGS) $<
 
-{$(TOP)/test}.c.obj:
+{$(TOP)/test}.c.obj::
 	$(CC) -c -I$(TOP) $(WFLAGS) $(CFLAGS) $<
 
-{$(TOP)/contrib/masmx64}.c.obj:
+{$(TOP)/contrib/masmx64}.c.obj::
 	$(CC) -c $(WFLAGS) $(CFLAGS) $<
 
 {$(TOP)/contrib/masmx64}.asm.obj:


### PR DESCRIPTION
Currently NMake based build invokes cl.exe for every file. This pull request enable NMake batch-mode rules for cl.exe. In this case cl.exe invoked for multiple .c files.