### PR TITLE
Set $LDSHARED variable on AIX, too

### DIFF
--- a/configure
+++ b/configure
@@ -253,6 +253,7 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
             SHAREDLIB='libz.sl' ;;
         esac ;;
   AIX*)
+        LDSHARED=${LDSHARED-"$cc -shared"}
         LDFLAGS="${LDFLAGS} -Wl,-brtl" ;;
   Darwin* | darwin* | *-darwin*)
         shared_ext='.dylib'


### PR DESCRIPTION
Otherwise, shared library not built. Excerpt from configure.log:

	Checking for shared library support...
	=== ztest1441980.c ===
	extern int getchar();
	int hello() {return getchar();}
	===
	gcc -w -c -O3 -fPIC ztest1441980.c
	-O3 -fPIC -o ztest1441980.so ztest1441980.o
	./configure[3]: -O3:  not found
	(exit code 127)
	No shared library support.

Relevant part of configure script:

	  if try $CC -w -c $SFLAGS $test.c &&
	     try $LDSHARED $SFLAGS -o $test$shared_ext $test.o; then
	    echo Building shared library $SHAREDLIBV with $CC. | tee -a configure.log
	  elif test -z "$old_cc" -a -z "$old_cflags"; then
	    echo No shared library support. | tee -a configure.log

Regressed with introduction of dedicated `case` section for AIX in commit 0091cb02819dfd0bd83329831b68e4280ccbc5a4