### PR TITLE
minizip: Fix incorrect cast in ioapi.c

### DIFF
--- a/contrib/minizip/ioapi.c
+++ b/contrib/minizip/ioapi.c
@@ -208,7 +208,7 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
     }
     ret = 0;
 
-    if(FSEEKO_FUNC((FILE *)stream, (z_off_t)offset, fseek_origin) != 0)
+    if(FSEEKO_FUNC((FILE *)stream, (z_off64_t)offset, fseek_origin) != 0)
                         ret = -1;
 
     return ret;


### PR DESCRIPTION
Followup fix for https://github.com/madler/zlib/issues/671 - on Win32 z_off_t is 32-bit.