### PR TITLE
Remove unsetting _FILE_OFFSET_BITS

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -3,15 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-#ifdef _LARGEFILE64_SOURCE
-#  ifndef _LARGEFILE_SOURCE
-#    define _LARGEFILE_SOURCE 1
-#  endif
-#  ifdef _FILE_OFFSET_BITS
-#    undef _FILE_OFFSET_BITS
-#  endif
-#endif
-
 #ifdef HAVE_HIDDEN
 #  define ZLIB_INTERNAL __attribute__((visibility ("hidden")))
 #else


### PR DESCRIPTION
This does not work when enabling 64bit time_t with glibc which is enabled with -D_TIME_BITS=64, since it also needs
_FILE_OFFSET_BITS=64 and this does not work when its undefined explicitly

Signed-off-by: Khem Raj <raj.khem@gmail.com>