### PR TITLE
minizip: Convert old K&R function definition

### DIFF
--- a/contrib/minizip/ioapi.c
+++ b/contrib/minizip/ioapi.c
@@ -231,8 +231,7 @@ static int ZCALLBACK ferror_file_func (voidpf opaque, voidpf stream)
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+void fill_fopen_filefunc (zlib_filefunc_def* pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;


### PR DESCRIPTION
All the other functions in the same file were converted from K&R style to normal function argument declarations in d004b047838a7e803818b4973a2e39e0ff8c1fa2