### PR TITLE
make darwin cross compilation possible

### DIFF
--- a/configure
+++ b/configure
@@ -260,7 +260,9 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
         SHAREDLIBV=libz.$VER$shared_ext
         SHAREDLIBM=libz.$VER1$shared_ext
         LDSHARED=${LDSHARED-"$cc -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER3"}
-        if libtool -V 2>&1 | grep Apple > /dev/null; then
+        if "${CROSS_PREFIX}libtool" -V 2>&1 | grep Apple > /dev/null; then
+            AR="${CROSS_PREFIX}libtool"
+        elif libtool -V 2>&1 | grep Apple > /dev/null; then
             AR="libtool"
         else
             AR="/usr/bin/libtool"


### PR DESCRIPTION
This pr makes the configure script check for `${CROSS_PREFIX}libtool` so users with toolchains like https://github.com/tpoechtrager/cctools-port can more easily cross compile zlib