### PR TITLE
(Minizip) Fix truncation of 64-bit offset to 32 bit causing corrupt output zips over 2GB

### DIFF
--- a/contrib/minizip/ioapi.c
+++ b/contrib/minizip/ioapi.c
@@ -208,7 +208,7 @@ static long ZCALLBACK fseek64_file_func (voidpf  opaque, voidpf stream, ZPOS64_T
     }
     ret = 0;
 
-    if(FSEEKO_FUNC((FILE *)stream, (z_off_t)offset, fseek_origin) != 0)
+    if(FSEEKO_FUNC((FILE *)stream, (z_off64_t)offset, fseek_origin) != 0)
                         ret = -1;
 
     return ret;


### PR DESCRIPTION
2014a993addbc8f1b9785d97f55fd189792c2f78 introduced a bug that caused output zips created with minizip larger than 2GB to be corrupt. It added a cast to `long` on the 64-bit offset in `fseek64_file_func`. This change avoids the truncation error by casting to the correct bit width while avoiding the unsigned to signed warnings the original commit was intended to remove.