### PR TITLE
Updated CMakeLists.txt to minimum cmake 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.4.4)
+cmake_minimum_required(VERSION 2.4.4...3.15.0)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS ON)
 
 project(zlib C)


### PR DESCRIPTION
CMake is complaining of a very low cmake support version, so is recommended upgrade its version