### PR TITLE
zran enable down-version zlib random-access clients using byte-aligned indexes

### DIFF
--- a/examples/zran.h
+++ b/examples/zran.h
@@ -10,7 +10,7 @@
 typedef struct point {
     off_t out;          // offset in uncompressed data
     off_t in;           // offset in compressed file of first full byte
-    int bits;           // 0, or number of bits (1-7) from byte at in-1
+    //int bits;           // 0, or number of bits (1-7) from byte at in-1
     unsigned char window[32768];    // preceding 32K of uncompressed data
 } point_t;
 


### PR DESCRIPTION
the zran indexes and similar tools include non-byte-alignment compressed entrypoints.   

I believe that byte-aligned compressed entrypoints simplifies the index, the serde, and relaxes the version particularly where Oracle JDK and JZLib java clients are bound to zlib 1.1.x which works for most files you encounter, but cannot call inflatePrime.
