### PR TITLE
gzgets should take an unsigned integer, not a signed one

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -539,7 +539,7 @@ int ZEXPORT gzungetc(c, file)
 char * ZEXPORT gzgets(file, buf, len)
     gzFile file;
     char *buf;
-    int len;
+    unsigned int len;
 {
     unsigned left, n;
     char *str;
@@ -547,7 +547,7 @@ char * ZEXPORT gzgets(file, buf, len)
     gz_statep state;
 
     /* check parameters and get internal structure */
-    if (file == NULL || buf == NULL || len < 1)
+    if (file == NULL || buf == NULL || !len)
         return NULL;
     state = (gz_statep)file;
 

--- a/test/example.c
+++ b/test/example.c
@@ -176,7 +176,7 @@ void test_gzio(fname, uncompr, uncomprLen)
         exit(1);
     }
 
-    gzgets(file, (char*)uncompr, (int)uncomprLen);
+    gzgets(file, (char*)uncompr, uncomprLen);
     if (strlen((char*)uncompr) != 7) { /* " hello!" */
         fprintf(stderr, "gzgets err after gzseek: %s\n", gzerror(file, &err));
         exit(1);

--- a/zlib.h
+++ b/zlib.h
@@ -1488,7 +1488,7 @@ ZEXTERN int ZEXPORT gzputs OF((gzFile file, const char *s));
      gzputs returns the number of characters written, or -1 in case of error.
 */
 
-ZEXTERN char * ZEXPORT gzgets OF((gzFile file, char *buf, int len));
+ZEXTERN char * ZEXPORT gzgets OF((gzFile file, char *buf, unsigned len));
 /*
      Read and decompress bytes from file into buf, until len-1 characters are
    read, or until a newline character is read and transferred to buf, or an


### PR DESCRIPTION
Every usage of this function intends on passing an unsigned integer anyway, as they do in gzread or gzwrite.

I found bugs where to prevent overflow before calling this function, programmers checked for UINT_MAX, and not INT_MAX.