### PR TITLE
CMakeLists.txt: Fix add_subdirectory build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ if(MSVC)
     set(CMAKE_DEBUG_POSTFIX "d")
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
-    include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_CURRENT_BINARY_DIR)
@@ -80,7 +79,7 @@ configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
 		${ZLIB_PC} @ONLY)
 configure_file(	${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
 		${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
-include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 
 
 #============================================================================


### PR DESCRIPTION
When zlib is built via an add_subdirectory() call, ${CMAKE_SOURCE_DIR} is the source directory of the parent project. Use ${CMAKE_CURRENT_SOURCE_DIR} instead to refer to the source directory of the zlib project.

Remove a redundant include_directories(${CMAKE_CURRENT_SOURCE_DIR}) call in the if(MSVC) block.

Note: This pull request is essentially the same as https://github.com/madler/zlib/pull/471. The only difference is to use MAKE_CURRENT_SOURCE_DIR instead of PROJECT_SOURCE_DIR.