### PR TITLE
fix-issue-447: Time bits macro changes required to pass compilation and tests

### DIFF
--- a/configure
+++ b/configure
@@ -516,8 +516,16 @@ cat > $test.c <<EOF
 off64_t dummy = 0;
 EOF
 if try $CC -c $CFLAGS -D_LARGEFILE64_SOURCE=1 $test.c; then
-  CFLAGS="${CFLAGS} -D_LARGEFILE64_SOURCE=1"
-  SFLAGS="${SFLAGS} -D_LARGEFILE64_SOURCE=1"
+  case ${CFLAGS} in
+    *"_TIME_BITS="*|*"_FILE_OFFSET_BITS="*)
+      echo "_TIME_BITS or _FILE_OFFSET_BITS defined, this is incompatible with _LARGEFILE64_SOURCE, not setting the latter"
+      ;;
+    *)
+      echo "Setting _LARGEFILE64_SOURCE"
+      CFLAGS="${CFLAGS} -D_LARGEFILE64_SOURCE=1"
+      SFLAGS="${SFLAGS} -D_LARGEFILE64_SOURCE=1"
+      ;;
+  esac
   ALL="${ALL} all64"
   TEST="${TEST} test64"
   echo "Checking for off64_t... Yes." | tee -a configure.log

--- a/gzguts.h
+++ b/gzguts.h
@@ -9,6 +9,7 @@
 #  endif
 #  ifdef _FILE_OFFSET_BITS
 #    undef _FILE_OFFSET_BITS
+#    undef _TIME_BITS
 #  endif
 #endif
 


### PR DESCRIPTION
Hi Team,

This is a potential fix for issue #447, namely supporting 64 bit time on 32 bit systems (Y2038 problem)
The current build of zlib attempts to use `_LARGEFILE64_SOURCE` when it is found to be supported by the compiler. This macro is incompatible with `_FILE_OFFSET_BITS`, and a rudimentary check for this exists in `gzguts.h`

From the compiler documentation:
https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#:~:text=Whereas%20_LARGEFILE64_SOURCE%20makes%20the%2064,bits%20on%2032%20bit%20systems.

> Macro: `_FILE_OFFSET_BITS`
> This macro determines which file system interface shall be used, one replacing the other. Whereas `_LARGEFILE64_SOURCE` makes the 64 bit interface available as an additional interface, `_FILE_OFFSET_BITS` allows the 64 bit interface to replace the old interface.

I'm proposing these changes to the configure script to allow `_FILE_OFFSET_BITS` / `_TIME_BITS` macros to take precedence if the user chooses to define them.

Any feedback would be greatly appreciated. 