### PR TITLE
Do not specify non-existant gcc version on macOS runners

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,7 +54,7 @@ jobs:
 
           - name: macOS GCC
             os: macos-latest
-            compiler: gcc-9
+            compiler: gcc-11
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -85,7 +85,7 @@ jobs:
 
           - name: macOS GCC
             os: macos-latest
-            compiler: gcc-9
+            compiler: gcc-11
             configure-args: --warn
 
           - name: macOS Clang


### PR DESCRIPTION
At some point, `macos-latest` stopped supporting `gcc-9`, and moved to `gcc-11` and `gcc-12`.

Currently supported compilers as reported in the [actions/runner-images](https://github.com/actions/runner-images) repository, with `macos-latest` pointing to `macos-12`:
* [macOS 11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md) (`macos-11`)
  - Clang/LLVM 13.0.0
  - Clang/LLVM (Homebrew) 15.0.7
  - GCC 10 (Homebrew GCC 10.4.0)
  - GCC 11 (Homebrew GCC 11.4.0)
  - GCC 12 (Homebrew GCC 12.3.0)
* [macOS 12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md) (`macos-12`, `macos-latest`)
  - Clang/LLVM 14.0.0
  - Clang/LLVM (Homebrew) 15.0.7
  - GCC 11 (Homebrew GCC 11.4.0)
  - GCC 12 (Homebrew GCC 12.3.0)
* [macOS 13](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md) (`macos-13`)
  - Clang/LLVM 14.0.0
  - Clang/LLVM (Homebrew) 15.0.7
  - GCC 11 (Homebrew GCC 11.4.0)
  - GCC 12 (Homebrew GCC 12.3.0)