### PR TITLE
minizip: Check length of comment, filename, and extra field, in zipOpenNewFileInZip4_64

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1043,6 +1043,17 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
       return ZIP_PARAMERROR;
 #endif
 
+    // The filename and comment length must fit in 16 bits.
+    if ((filename!=NULL) && (strlen(filename)>0xffff))
+        return ZIP_PARAMERROR;
+    if ((comment!=NULL) && (strlen(comment)>0xffff))
+        return ZIP_PARAMERROR;
+    // The extra field length must fit in 16 bits. If the member also requires
+    // a Zip64 extra block, that will also need to fit within that 16-bit
+    // length, but that will be checked for later.
+    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff))
+        return ZIP_PARAMERROR;
+
     zi = (zip64_internal*)file;
 
     if (zi->in_opened_file_inzip == 1)


### PR DESCRIPTION
These are stored in 16-bit fields in the zip file format. Passing longer values would generate an invalid file.

Passing very long values could also cause the computation of zi->ci.size_centralheader to overflow, which would cause heap buffer overflow on subsequent writes to zi->ci.central_header.

This was reported to Chromium in https://crbug.com/1470539, and patched in https://crrev.com/1182507 and https://crrev.com/1182669