### PR TITLE
Create LICENSE.Info-Zip

### DIFF
--- a/contrib/minizip/LICENSE.Info-Zip
+++ b/contrib/minizip/LICENSE.Info-Zip
@@ -1,0 +1,58 @@
+This is version 2009-Jan-02 of the Info-ZIP license. The definitive version of
+this document should be available at ftp://ftp.info-
+zip.org/pub/infozip/license.html indefinitely and a copy at http://www.info-
+zip.org/pub/infozip/license.html.
+
+Copyright (c) 1990-2009 Info-ZIP. All rights reserved.
+
+For the purposes of this copyright and license, "Info-ZIP" is defined as the
+following set of individuals:
+
+    Mark Adler, John Bush, Karl Davis, Harald Denker, Jean-Michel Dubois, Jean-
+    loup Gailly, Hunter Goatley, Ed Gordon, Ian Gorman, Chris Herborth, Dirk
+    Haase, Greg Hartwig, Robert Heath, Jonathan Hudson, Paul Kienitz, David
+    Kirschbaum, Johnny Lee, Onno van der Linden, Igor Mandrichenko, Steve P.
+    Miller, Sergio Monesi, Keith Owens, George Petrov, Greg Roelofs, Kai Uwe
+    Rommel, Steve Salisbury, Dave Smith, Steven M. Schweda, Christian Spieler,
+    Cosmin Truta, Antoine Verheijen, Paul von Behren, Rich Wales, Mike White.
+
+This software is provided "as is," without warranty of any kind, express or
+implied. In no event shall Info-ZIP or its contributors be held liable for any
+direct, indirect, incidental, special or consequential damages arising out of
+the use of or inability to use this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject to
+the above disclaimer and the following restrictions:
+
+    Redistributions of source code (in whole or in part) must retain the above
+    copyright notice, definition, disclaimer, and this list of conditions.
+
+    Redistributions in binary form (compiled executables and libraries) must
+    reproduce the above copyright notice, definition, disclaimer, and this list
+    of conditions in documentation and/or other materials provided with the
+    distribution. Additional documentation is not needed for executables where a
+    command line license option provides these and a note regarding this option
+    is in the executable's startup banner. The sole exception to this condition
+    is redistribution of a standard UnZipSFX binary (including SFXWiz) as part
+    of a self-extracting archive; that is permitted without inclusion of this
+    license, as long as the normal SFX banner has not been removed from the
+    binary or disabled.
+
+    Altered versions--including, but not limited to, ports to new operating
+    systems, existing ports with new graphical interfaces, versions with
+    modified or added functionality, and dynamic, shared, or static library
+    versions not from Info-ZIP--must be plainly marked as such and must not be
+    misrepresented as being the original source or, if binaries, compiled from
+    the original source. Such altered versions also must not be misrepresented
+    as being Info-ZIP releases--including, but not limited to, labeling of the
+    altered versions with the names "Info-ZIP" (or any variation thereof,
+    including, but not limited to, different capitalizations), "Pocket UnZip,"
+    "WiZ" or "MacZip" without the explicit permission of Info-ZIP. Such altered
+    versions are further prohibited from misrepresentative use of the Zip-Bugs
+    or Info-ZIP e-mail addresses or the Info-ZIP URL(s), such as to imply Info-
+    ZIP will provide support for the altered versions.
+
+    Info-ZIP retains the right to use the names "Info-ZIP," "Zip," "UnZip,"
+    "UnZipSFX," "WiZ," "Pocket UnZip," "Pocket Zip," and "MacZip" for its own
+    source and binary releases.


### PR DESCRIPTION
While unzip.c references this license as being derived from, it was not copied though this is explicitly mandated by the Info-Zip license.

Unfortunately, [plain-text version on the Info-Zip website](http://info-zip.org/doc/LICENSE) contains a different (2007) version of the license, so I took this one [from scancode-toolkit](https://github.com/nexB/scancode-toolkit/blob/develop/src/licensedcode/data/licenses/info-zip-2009-01.LICENSE).

