### PR TITLE
Address C4244 warnings in MSVC build

### DIFF
--- a/deflate.c
+++ b/deflate.c
@@ -1646,10 +1646,10 @@ local block_state deflate_stored(deflate_state *s, int flush) {
         _tr_stored_block(s, (char *)0, 0L, last);
 
         /* Replace the lengths in the dummy stored block with len. */
-        s->pending_buf[s->pending - 4] = len;
-        s->pending_buf[s->pending - 3] = len >> 8;
-        s->pending_buf[s->pending - 2] = ~len;
-        s->pending_buf[s->pending - 1] = ~len >> 8;
+        s->pending_buf[s->pending - 4] = (Bytef)len;
+        s->pending_buf[s->pending - 3] = (Bytef)(len >> 8);
+        s->pending_buf[s->pending - 2] = (Bytef)~len;
+        s->pending_buf[s->pending - 1] = (Bytef)(~len >> 8);
 
         /* Write the stored block header bytes. */
         flush_pending(s->strm);

--- a/trees.c
+++ b/trees.c
@@ -724,7 +724,7 @@ local void scan_tree(deflate_state *s, ct_data *tree, int max_code) {
         if (++count < max_count && curlen == nextlen) {
             continue;
         } else if (count < min_count) {
-            s->bl_tree[curlen].Freq += count;
+            s->bl_tree[curlen].Freq += (ush)count;
         } else if (curlen != 0) {
             if (curlen != prevlen) s->bl_tree[curlen].Freq++;
             s->bl_tree[REP_3_6].Freq++;


### PR DESCRIPTION
Allows the MSVC build to compile clean when the [C4244 warning code](https://learn.microsoft.com/cpp/error-messages/compiler-warnings/compiler-warning-levels-3-and-4-c4244) (checking for potentially lossy implicit integer narrowing casts) is enabled. I've tried to follow the same coding convention as was used in https://github.com/madler/zlib/commit/3df842426b53522e232da7aa06d5ef10eeb5ec4a.

An analysis our review team performed to convince ourselves of the correctness of the changes...

The change to deflate.c is legal because 'len' has an upper bound of MAX_STORED, which means it fits cleanly into a 16-bit integer. So writing out 2x 8-bit values will not result in data loss.

The change to trees.c is legal because within this loop, 'count' is intended to have an upper bound of 138, with the target assignment only executing if 'count' is bounded by 4. Neither the 'count' local in isolation nor the addition that's part of the target line is expected to result in integer overflow. But even if it did, that's a matter for a different warning code and doesn't impact the correctness of the narrowing cast being considered here.