### PR TITLE
examples: define functions as static ones.

### DIFF
--- a/test/example.c
+++ b/test/example.c
@@ -36,12 +36,12 @@ static uLong dictId;    /* Adler32 value of the dictionary */
 
 #ifdef Z_SOLO
 
-void *myalloc(void *q, unsigned n, unsigned m) {
+static void *myalloc(void *q, unsigned n, unsigned m) {
     (void)q;
     return calloc(n, m);
 }
 
-void myfree(void *q, void *p) {
+static void myfree(void *q, void *p) {
     (void)q;
     free(p);
 }
@@ -57,7 +57,7 @@ static free_func zfree = (free_func)0;
 /* ===========================================================================
  * Test compress() and uncompress()
  */
-void test_compress(Byte *compr, uLong comprLen, Byte *uncompr,
+static void test_compress(Byte *compr, uLong comprLen, Byte *uncompr,
                    uLong uncomprLen) {
     int err;
     uLong len = (uLong)strlen(hello)+1;
@@ -81,7 +81,7 @@ void test_compress(Byte *compr, uLong comprLen, Byte *uncompr,
 /* ===========================================================================
  * Test read/write of .gz files
  */
-void test_gzio(const char *fname, Byte *uncompr, uLong uncomprLen) {
+static void test_gzio(const char *fname, Byte *uncompr, uLong uncomprLen) {
 #ifdef NO_GZCOMPRESS
     fprintf(stderr, "NO_GZCOMPRESS -- gz* functions cannot compress\n");
 #else
@@ -163,7 +163,7 @@ void test_gzio(const char *fname, Byte *uncompr, uLong uncomprLen) {
 /* ===========================================================================
  * Test deflate() with small buffers
  */
-void test_deflate(Byte *compr, uLong comprLen) {
+static void test_deflate(Byte *compr, uLong comprLen) {
     z_stream c_stream; /* compression stream */
     int err;
     uLong len = (uLong)strlen(hello)+1;
@@ -198,7 +198,7 @@ void test_deflate(Byte *compr, uLong comprLen) {
 /* ===========================================================================
  * Test inflate() with small buffers
  */
-void test_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
+static void test_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
                   uLong uncomprLen) {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -237,7 +237,7 @@ void test_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
 /* ===========================================================================
  * Test deflate() with large buffers and dynamic change of compression level
  */
-void test_large_deflate(Byte *compr, uLong comprLen, Byte *uncompr,
+static void test_large_deflate(Byte *compr, uLong comprLen, Byte *uncompr,
                         uLong uncomprLen) {
     z_stream c_stream; /* compression stream */
     int err;
@@ -290,7 +290,7 @@ void test_large_deflate(Byte *compr, uLong comprLen, Byte *uncompr,
 /* ===========================================================================
  * Test inflate() with large buffers
  */
-void test_large_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
+static void test_large_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
                         uLong uncomprLen) {
     int err;
     z_stream d_stream; /* decompression stream */
@@ -329,7 +329,7 @@ void test_large_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
 /* ===========================================================================
  * Test deflate() with full flush
  */
-void test_flush(Byte *compr, uLong *comprLen) {
+static void test_flush(Byte *compr, uLong *comprLen) {
     z_stream c_stream; /* compression stream */
     int err;
     uInt len = (uInt)strlen(hello)+1;
@@ -364,7 +364,7 @@ void test_flush(Byte *compr, uLong *comprLen) {
 /* ===========================================================================
  * Test inflateSync()
  */
-void test_sync(Byte *compr, uLong comprLen, Byte *uncompr, uLong uncomprLen) {
+static void test_sync(Byte *compr, uLong comprLen, Byte *uncompr, uLong uncomprLen) {
     int err;
     z_stream d_stream; /* decompression stream */
 
@@ -404,7 +404,7 @@ void test_sync(Byte *compr, uLong comprLen, Byte *uncompr, uLong uncomprLen) {
 /* ===========================================================================
  * Test deflate() with preset dictionary
  */
-void test_dict_deflate(Byte *compr, uLong comprLen) {
+static void test_dict_deflate(Byte *compr, uLong comprLen) {
     z_stream c_stream; /* compression stream */
     int err;
 
@@ -438,7 +438,7 @@ void test_dict_deflate(Byte *compr, uLong comprLen) {
 /* ===========================================================================
  * Test inflate() with a preset dictionary
  */
-void test_dict_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
+static void test_dict_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
                        uLong uncomprLen) {
     int err;
     z_stream d_stream; /* decompression stream */

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -149,12 +149,12 @@ static void pwinerror (s)
 #  include <unistd.h>       /* for unlink() */
 #endif
 
-void *myalloc(void *q, unsigned n, unsigned m) {
+static void *myalloc(void *q, unsigned n, unsigned m) {
     (void)q;
     return calloc(n, m);
 }
 
-void myfree(void *q, void *p) {
+static void myfree(void *q, void *p) {
     (void)q;
     free(p);
 }
@@ -167,7 +167,7 @@ typedef struct gzFile_s {
     z_stream strm;
 } *gzFile;
 
-gzFile gz_open(const char *path, int fd, const char *mode) {
+static gzFile gz_open(const char *path, int fd, const char *mode) {
     gzFile gz;
     int ret;
 
@@ -201,15 +201,15 @@ gzFile gz_open(const char *path, int fd, const char *mode) {
     return gz;
 }
 
-gzFile gzopen(const char *path, const char *mode) {
+static gzFile gzopen(const char *path, const char *mode) {
     return gz_open(path, -1, mode);
 }
 
-gzFile gzdopen(int fd, const char *mode) {
+static gzFile gzdopen(int fd, const char *mode) {
     return gz_open(NULL, fd, mode);
 }
 
-int gzwrite(gzFile gz, const void *buf, unsigned len) {
+static int gzwrite(gzFile gz, const void *buf, unsigned len) {
     z_stream *strm;
     unsigned char out[BUFLEN];
 
@@ -227,7 +227,7 @@ int gzwrite(gzFile gz, const void *buf, unsigned len) {
     return len;
 }
 
-int gzread(gzFile gz, void *buf, unsigned len) {
+static int gzread(gzFile gz, void *buf, unsigned len) {
     int ret;
     unsigned got;
     unsigned char in[1];
@@ -258,7 +258,7 @@ int gzread(gzFile gz, void *buf, unsigned len) {
     return len - strm->avail_out;
 }
 
-int gzclose(gzFile gz) {
+static int gzclose(gzFile gz) {
     z_stream *strm;
     unsigned char out[BUFLEN];
 
@@ -283,7 +283,7 @@ int gzclose(gzFile gz) {
     return Z_OK;
 }
 
-const char *gzerror(gzFile gz, int *err) {
+static const char *gzerror(gzFile gz, int *err) {
     *err = gz->err;
     return gz->msg;
 }
@@ -295,7 +295,7 @@ static char *prog;
 /* ===========================================================================
  * Display error message and exit
  */
-void error(const char *msg) {
+static void error(const char *msg) {
     fprintf(stderr, "%s: %s\n", prog, msg);
     exit(1);
 }
@@ -305,7 +305,7 @@ void error(const char *msg) {
 /* Try compressing the input file at once using mmap. Return Z_OK if
  * if success, Z_ERRNO otherwise.
  */
-int gz_compress_mmap(FILE *in, gzFile out) {
+static int gz_compress_mmap(FILE *in, gzFile out) {
     int len;
     int err;
     int ifd = fileno(in);
@@ -338,7 +338,7 @@ int gz_compress_mmap(FILE *in, gzFile out) {
  * Compress input to output then close both files.
  */
 
-void gz_compress(FILE *in, gzFile out) {
+static void gz_compress(FILE *in, gzFile out) {
     local char buf[BUFLEN];
     int len;
     int err;
@@ -366,7 +366,7 @@ void gz_compress(FILE *in, gzFile out) {
 /* ===========================================================================
  * Uncompress input to output then close both files.
  */
-void gz_uncompress(gzFile in, FILE *out) {
+static void gz_uncompress(gzFile in, FILE *out) {
     local char buf[BUFLEN];
     int len;
     int err;
@@ -390,7 +390,7 @@ void gz_uncompress(gzFile in, FILE *out) {
  * Compress the given file: create a corresponding .gz file and remove the
  * original.
  */
-void file_compress(char *file, char *mode) {
+static void file_compress(char *file, char *mode) {
     local char outfile[MAX_NAME_LEN];
     FILE  *in;
     gzFile out;
@@ -426,7 +426,7 @@ void file_compress(char *file, char *mode) {
 /* ===========================================================================
  * Uncompress the given file and remove the original.
  */
-void file_uncompress(char *file) {
+static void file_uncompress(char *file) {
     local char buf[MAX_NAME_LEN];
     char *infile, *outfile;
     FILE  *out;


### PR DESCRIPTION
This fixes warnings when building with -Wmissing-prototypes.