### PR TITLE
Keep the interface stable

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -579,4 +579,9 @@ unsigned ZLIB_INTERNAL gz_intmax(void) {
     } while (p > q);
     return q >> 1;
 }
+#else
+unsigned ZLIB_INTERNAL gz_intmax()
+{
+    return INT_MAX;
+}
 #endif


### PR DESCRIPTION
Android NDK r26 is featuring clang 17 compiler, which errors out in the case when gz_intmax is mentioned in zlib.map, yet it's not part of the code base (in case INT_MAX is defined).

Also with this PR, the zlib interface becomes more stable over compiler & toolchain changes.

This is the compiler error:
```
ld.lld: error: version script assignment of 'local' to symbol 'gz_intmax' failed: symbol not defined
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

This PR is a proper fix for #856.