### PR TITLE
fix case of MSDOS

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -79,7 +79,7 @@
 
 /* change_file_date : change the date/time of a file
     filename : the filename of the file where date/time must be modified
-    dosdate : the new date at the MSDos format (4 bytes)
+    dosdate : the new date at the MSDOS format (4 bytes)
     tmu_date : the SAME new date at the tm_unz format */
 static void change_file_date(const char *filename, uLong dosdate, tm_unz tmu_date) {
 #ifdef _WIN32


### PR DESCRIPTION
Should be "MSDOS".  The all-caps version is used consistently throughout the code, with the exception of this one line in miniunz.c.

No functional change.