### PR TITLE
fix misspelling in code comment

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -117,7 +117,7 @@
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
-/* unz_file_info_interntal contain internal info about a file in zipfile*/
+/* unz_file_info64_internal contain internal info about a file in zipfile*/
 typedef struct unz_file_info64_internal_s
 {
     ZPOS64_T offset_curfile;/* relative offset of local header 8 bytes */


### PR DESCRIPTION
Should be "unz_file_info64_internal", consistent with other comments on typedefs in this file, for example see code comment on unz64_s.

No functional change.