### PR TITLE
Fix platform check for macOS

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -137,15 +137,11 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if TARGET_OS_OSX
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os
 #      include <unix.h> /* for fdopen */
-#    else
-#      ifndef fdopen
-#        define fdopen(fd,mode) NULL /* No fdopen() */
-#      endif
 #    endif
 #  endif
 #endif


### PR DESCRIPTION
`zutils.h` contains configurations that are no longer exercised for the macOS target.
- The target OS conditional macros are misused. Specifically `TARGET_OS_MAC` covers all Apple targets, including iOS, and it should not be checked with `#if defined` as they would always be defined (to either 1 or 0) on Apple platforms.
- The assumption that macOS does not have `fdopen`, or defines `fdopen` as a macro is no longer valid. The null definition in `zutils.h` would conflict with the macOS SDK and cause a compilation failure.

This problem has not been noticed until a recent extension in clang (https://github.com/llvm/llvm-project/pull/74676) exposed the issue and broke zlib builds on Apple platforms.