### PR TITLE
Fix "pendingBuf overflow" assert in LIT_MEM mode

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -938,7 +938,8 @@ local void compress_block(deflate_state *s, const ct_data *ltree,
 
         /* Check for no overlay of pending_buf on needed symbols */
 #ifdef LIT_MEM
-        Assert(s->pending < (s->lit_bufsize << 1) + sx, "pendingBuf overflow");
+        Assert(s->pending < (s->lit_bufsize << 1) + (sx << 1),
+               "pendingBuf overflow");
 #else
         Assert(s->pending < s->lit_bufsize + sx, "pendingBuf overflow");
 #endif


### PR DESCRIPTION
Since each element in s->d_buf is 2 bytes, the sx index should be multiplied by 2 in the assert.

Fixes #897