### PR TITLE
cast the result of multiplication to size_t before passing it to the malloc function

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -285,7 +285,7 @@ extern void free(voidpf ptr);
 
 voidpf ZLIB_INTERNAL zcalloc(voidpf opaque, unsigned items, unsigned size) {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+    return sizeof(uInt) > 2 ? (voidpf)malloc((z_size_t)items * size) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
`items` and `size` have the `unsigned int` type (32-bit).
So the result of multiplication also will be 32-bit while malloc takes `size_t`.
E.g. at values `0x80000000` and `0x2` `malloc` will take `0` when should take `0x100000000` on 64-bit systems.

Such issues may lead to memory corruptions because the allocated buffer size will be smaller than expected. However, in the `zlib` codebase, a vulnerable function is always called with controlled parameters, so for now there are no security concerns here.