### PR TITLE
contrib/minizip: neutralize traversal attacks in miniunz cli

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -356,6 +356,20 @@ static int do_extract_currentfile(unzFile uf, const int* popt_extract_without_pa
         else
             write_filename = filename_withoutpath;
 
+        if (write_filename[0]!='\0')
+        {
+            const char* relative_check = write_filename;
+            while (relative_check[1]!='\0')
+            {
+                if (relative_check[0]=='.' && relative_check[1]=='.')
+                    write_filename = relative_check;
+                relative_check++;
+            }
+        }
+
+        while (write_filename[0]=='/' || write_filename[0]=='.')
+            write_filename++;
+
         err = unzOpenCurrentFilePassword(uf,password);
         if (err!=UNZ_OK)
         {


### PR DESCRIPTION
Archive formats such as .zip files are generally susceptible to so-called "traversal attacks". This allows an attacker to craft an archive that writes to unexpected locations of the file system (e.g., /etc/shadow) if an unspecting root user were to unpack a malicious archive.

This patch neutralizes absolute paths such as /tmp/moo and deeply relative paths such as dummy/../../../../../../../../../../../../../../../../../tmp/moo

The Debian project requested CVE-2014-9485 be allocated for the first identified weakness. The fix was incomplete, resulting in a revised patch applied here. Since there wasn't an updated version released by Debian with the incomplete fix, I suggest we use this CVE to identify both issues.

Fixes: #907
Link: https://security.snyk.io/research/zip-slip-vulnerability
Link: https://bugs.debian.org/774321
Link: https://bugs.debian.org/776831
Link: https://nvd.nist.gov/vuln/detail/CVE-2014-9485
Reported-by: Jakub Wilk <jwilk@debian.org>
Fixed-by: Michael Gilbert <mgilbert@debian.org>