### PR TITLE
miniunz: Ensure filenames read from a ZIP file are always null terminated

### DIFF
--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -240,12 +240,12 @@ static int do_list(unzFile uf) {
     printf("  ------  ------     ---- -----   ----    ----   ------     ----\n");
     for (i=0;i<gi.number_entry;i++)
     {
-        char filename_inzip[256];
+        char filename_inzip[257]={0};
         unz_file_info64 file_info;
         uLong ratio=0;
         const char *string_method = "";
         char charCrypt=' ';
-        err = unzGetCurrentFileInfo64(uf,&file_info,filename_inzip,sizeof(filename_inzip),NULL,0,NULL,0);
+        err = unzGetCurrentFileInfo64(uf,&file_info,filename_inzip,sizeof(filename_inzip)-1,NULL,0,NULL,0);
         if (err!=UNZ_OK)
         {
             printf("error %d with zipfile in unzGetCurrentFileInfo\n",err);
@@ -305,7 +305,7 @@ static int do_list(unzFile uf) {
 
 
 static int do_extract_currentfile(unzFile uf, const int* popt_extract_without_path, int* popt_overwrite, const char* password) {
-    char filename_inzip[256];
+    char filename_inzip[257]={0};
     char* filename_withoutpath;
     char* p;
     int err=UNZ_OK;
@@ -314,7 +314,7 @@ static int do_extract_currentfile(unzFile uf, const int* popt_extract_without_pa
     uInt size_buf;
 
     unz_file_info64 file_info;
-    err = unzGetCurrentFileInfo64(uf,&file_info,filename_inzip,sizeof(filename_inzip),NULL,0,NULL,0);
+    err = unzGetCurrentFileInfo64(uf,&file_info,filename_inzip,sizeof(filename_inzip)-1,NULL,0,NULL,0);
 
     if (err!=UNZ_OK)
     {


### PR DESCRIPTION
`unzGetCurrentFileInfo64` does not null terminate the `szFileName` if it's longer or equal to `fileNameBufferSize`.

To ensure the strings are null terminated in the calling code, increase the buffer size by one and initialize with zeros.

Fixes #869