### PR TITLE
Compiler warning with fileno when building with non-gnu C extensions

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -15,6 +15,10 @@
 
 /* @(#) $Id$ */
 
+#ifndef _POSIX_SOURCE
+#  define _POSIX_SOURCE
+#endif
+
 #include "zlib.h"
 #include <stdio.h>
 


### PR DESCRIPTION
Building zlib throws up this compiler warning when the non-gnu extensions are enabled - so that is with gcc & clang using the `-std` option with any of the values `c99`, `c11`, `c17`, and `c2x`. This issue was found using the workflow file contained in #925

```
gcc -std=c2x -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -I. -c -o minigzip.o test/minigzip.c
test/minigzip.c: In function ‘main’:
test/minigzip.c:538:28: warning: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
  538 |             file = gzdopen(fileno(stdin), "rb");
      |                            ^~~~~~
gcc -std=c2x -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -o minigzip minigzip.o -L. libz.a
gcc -std=c2x -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -o minigzipsh minigzip.o  -L. libz.so.1.3.1.1-motley
gcc -std=c2x -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -I. -D_FILE_OFFSET_BITS=64 -c -o minigzip64.o test/minigzip.c
test/minigzip.c: In function ‘main’:
test/minigzip.c:538:28: warning: implicit declaration of function ‘fileno’ [-Wimplicit-function-declaration]
  538 |             file = gzdopen(fileno(stdin), "rb");
      |                            ^~~~~~
gcc -std=c2x -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN  -o minigzip64 minigzip64.o -L. libz.a
```

Looking at `fileno` in `stdio.h` on my Ubuntu setup I see it is guarded by `__USE_POSIX`

```
#ifdef	__USE_POSIX
/* Return the system file descriptor for STREAM.  */
extern int fileno (FILE *__stream) __THROW __wur;
#endif /* Use POSIX.  */
```

This change mirrors what is done in `gzguts.h`  to define `_POSIX_SOURCE` if it isn't already defined.