### PR TITLE
Fix Broken Links

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -19,7 +19,7 @@ The latest zlib FAQ is at http://zlib.net/zlib_faq.html
  3. Where can I get a Visual Basic interface to zlib?
 
     See
-        * http://marknelson.us/1997/01/01/zlib-engine/
+        * https://marknelson.us/posts/1997/01/01/zlib-engine.html
         * win32/DLL_FAQ.txt in the zlib distribution
 
  4. compress() returns Z_BUF_ERROR.

--- a/contrib/ada/readme.txt
+++ b/contrib/ada/readme.txt
@@ -2,7 +2,7 @@
                         Release 1.3
 
 ZLib.Ada is a thick binding interface to the popular ZLib data
-compression library, available at http://www.gzip.org/zlib/.
+compression library, available at https://zlib.net/.
 It provides Ada-style access to the ZLib C library.
 
 

--- a/contrib/gcc_gvmat64/gvmat64.S
+++ b/contrib/gcc_gvmat64/gvmat64.S
@@ -177,7 +177,7 @@ printf("#define dsNiceMatch     %u\n",(int)(((char*)&(s->nice_match))-((char*)s)
 
 ;
 ; gcc on macosx-linux:
-; see http://www.x86-64.org/documentation/abi-0.99.pdf
+; see https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf
 ; param 1 in rdi, param 2 in rsi
 ; rbx, rsp, rbp, r12 to r15 must be preserved
 

--- a/qnx/package.qpg
+++ b/qnx/package.qpg
@@ -58,7 +58,7 @@
                <QPM:ProductIconLarge></QPM:ProductIconLarge>
                <QPM:ProductDescriptionShort>A massively spiffy yet delicately unobtrusive compression library.</QPM:ProductDescriptionShort>
                <QPM:ProductDescriptionLong>zlib is designed to be a free, general-purpose, legally unencumbered, lossless data compression library for use on virtually any computer hardware and operating system.</QPM:ProductDescriptionLong>
-               <QPM:ProductDescriptionURL>http://www.gzip.org/zlib</QPM:ProductDescriptionURL>
+               <QPM:ProductDescriptionURL>https://zlib.net/</QPM:ProductDescriptionURL>
                <QPM:ProductDescriptionEmbedURL></QPM:ProductDescriptionEmbedURL>
             </QPM:ProductDescription>
 

--- a/win32/DLL_FAQ.txt
+++ b/win32/DLL_FAQ.txt
@@ -6,7 +6,7 @@ This document describes the design, the rationale, and the usage
 of the common DLL build of zlib, named ZLIB1.DLL.  If you have
 general questions about zlib, you should see the file "FAQ" found
 in the zlib distribution, or at the following location:
-  http://www.gzip.org/zlib/zlib_faq.html
+  https://www.zlib.net/zlib_faq.html
 
 
  1. What is ZLIB1.DLL, and how can I get it?

--- a/zlib.3
+++ b/zlib.3
@@ -86,7 +86,7 @@ Mark Nelson wrote an article about
 for the Jan. 1997 issue of  Dr. Dobb's Journal;
 a copy of the article is available at:
 .IP
-http://marknelson.us/1997/01/01/zlib-engine/
+https://marknelson.us/posts/1997/01/01/zlib-engine.html
 .SH "REPORTING PROBLEMS"
 Before reporting a problem,
 please check the


### PR DESCRIPTION
### Description of change

I was fixing broken links in the [Racket programming language](https://github.com/racket/racket/pull/4930), in my pr over there, they told me to come here and upstream the fixes:

http://marknelson.us/1997/01/01/zlib-engine/ --> https://marknelson.us/posts/1997/01/01/zlib-engine.html

http://www.gzip.org/zlib --> https://zlib.net/

http://www.x86-64.org/documentation/abi-0.99.pdf --> https://refspecs.linuxbase.org/elf/x86_64-abi-0.99.pdf

### Support my work

These links where found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this PR useful, give the repo a ⭐