### PR TITLE
Improve detection of UNIX-style systems in minizip code

### DIFF
--- a/contrib/minizip/make_vms.com
+++ b/contrib/minizip/make_vms.com
@@ -2,7 +2,7 @@ $ if f$search("ioapi.h_orig") .eqs. "" then copy ioapi.h ioapi.h_orig
 $ open/write zdef vmsdefs.h
 $ copy sys$input: zdef
 $ deck
-#define unix
+#define __unix__
 #define fill_zlib_filefunc64_32_def_from_filefunc32 fillzffunc64from
 #define Write_Zip64EndOfCentralDirectoryLocator Write_Zip64EoDLocator
 #define Write_Zip64EndOfCentralDirectoryRecord Write_Zip64EoDRecord

--- a/contrib/minizip/miniunz.c
+++ b/contrib/minizip/miniunz.c
@@ -93,8 +93,7 @@ static void change_file_date(const char *filename, uLong dosdate, tm_unz tmu_dat
   LocalFileTimeToFileTime(&ftLocal,&ftm);
   SetFileTime(hFile,&ftm,&ftLastAcc,&ftm);
   CloseHandle(hFile);
-#else
-#if defined(unix) || defined(__APPLE__)
+#elif defined(__unix__) || defined(__unix) || defined(__APPLE__)
   (void)dosdate;
   struct utimbuf ut;
   struct tm newdate;
@@ -116,7 +115,6 @@ static void change_file_date(const char *filename, uLong dosdate, tm_unz tmu_dat
   (void)dosdate;
   (void)tmu_date;
 #endif
-#endif
 }
 
 
@@ -127,9 +125,7 @@ static int mymkdir(const char* dirname) {
     int ret=0;
 #ifdef _WIN32
     ret = _mkdir(dirname);
-#elif unix
-    ret = mkdir (dirname,0775);
-#elif __APPLE__
+#elif defined(__unix__) || defined(__unix) || defined(__APPLE__)
     ret = mkdir (dirname,0775);
 #else
     (void)dirname;

--- a/contrib/minizip/minizip.c
+++ b/contrib/minizip/minizip.c
@@ -91,8 +91,7 @@ static int filetime(const char *f, tm_zip *tmzip, uLong *dt) {
   }
   return ret;
 }
-#else
-#if defined(unix) || defined(__APPLE__)
+#elif defined(__unix__) || defined(__unix) || defined(__APPLE__)
 /* f: name of file to get info on, tmzip: return value: access,
    modification and creation times, dt: dostime */
 static int filetime(const char *f, tm_zip *tmzip, uLong *dt) {
@@ -142,7 +141,6 @@ static int filetime(const char *f, tm_zip *tmzip, uLong *dt) {
     (void)dt;
     return 0;
 }
-#endif
 #endif
 
 

--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -88,7 +88,7 @@
 
 
 #ifndef CASESENSITIVITYDEFAULT_NO
-#  if !defined(unix) && !defined(CASESENSITIVITYDEFAULT_YES)
+#  if (!defined(__unix__) && !defined(__unix) || defined(__CYGWIN__))  && !defined(CASESENSITIVITYDEFAULT_YES)
 #    define CASESENSITIVITYDEFAULT_NO
 #  endif
 #endif


### PR DESCRIPTION
Not all toolchains on UNIX-style operating systems predefine `unix`. For example, it's missing on NetBSD, OpenBSD/gcc, AIX, HP-UX. There is no single macro defined everywhere, but checking both `__unix__` and `__unix` should cover everything except macOS.

Note that we case sensitivity should default to off on macOS and cygwin, so the check there is different.

For a good (though somewhat dated) overview of predefined macros on various popular systems, see:
https://web.archive.org/web/20191012035921/http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system