### PR TITLE
change CI CMake build to use Open Watcom toolchain

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,32 @@ jobs:
             cflags: -Werror -Wall -Wextra
             build-config: Debug
 
+          - name: Ubuntu Open Watcom DOS 16-bit
+            os: ubuntu-latest
+            cflags: -ml
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=DOS -D CMAKE_SYSTEM_PROCESSOR=I86
+
+          - name: Ubuntu Open Watcom DOS 32-bit
+            os: ubuntu-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=DOS -D CMAKE_SYSTEM_PROCESSOR=X86
+
+          - name: Ubuntu Open Watcom OS/2 16-bit
+            os: ubuntu-latest
+            cflags: -ml
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=OS2 -D CMAKE_SYSTEM_PROCESSOR=I86
+
+          - name: Ubuntu Open Watcom OS/2 32-bit
+            os: ubuntu-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=OS2 -D CMAKE_SYSTEM_PROCESSOR=X86
+
+          - name: Ubuntu Open Watcom Windows 32-bit
+            os: ubuntu-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_SYSTEM_PROCESSOR=X86
+
+          - name: Ubuntu Open Watcom Linux 32-bit
+            os: ubuntu-latest
+            cmake-args: -G "Watcom WMake"
+
           - name: Windows MSVC Win32
             os: windows-latest
             compiler: cl
@@ -65,27 +91,57 @@ jobs:
             compiler: gcc-11
             cflags: -Werror -Wall -Wextra
 
+          - name: Windows Open Watcom DOS 16-bit
+            os: windows-latest
+            cflags: -ml
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=DOS -D CMAKE_SYSTEM_PROCESSOR=I86
+
+          - name: Windows Open Watcom DOS 32-bit
+            os: windows-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=DOS -D CMAKE_SYSTEM_PROCESSOR=X86
+
+          - name: Windows Open Watcom OS/2 16-bit
+            os: windows-latest
+            cflags: -ml
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=OS2 -D CMAKE_SYSTEM_PROCESSOR=I86
+
+          - name: Windows Open Watcom OS/2 32-bit
+            os: windows-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=OS2 -D CMAKE_SYSTEM_PROCESSOR=X86
+
+          - name: Windows Open Watcom Windows 32-bit
+            os: windows-latest
+            cmake-args: -G "Watcom WMake"
+
+          - name: Windows Open Watcom Linux 32-bit
+            os: windows-latest
+            cmake-args: -G "Watcom WMake" -D CMAKE_SYSTEM_NAME=Linux -D CMAKE_SYSTEM_PROCESSOR=X86
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Install packages (Open Watcom)
+      if: ${{ contains(matrix.name, 'Open Watcom') }}
+      uses: open-watcom/setup-watcom@v0
     - name: Install packages (Windows)
-      if: runner.os == 'Windows'
+      if: ${{ runner.os == 'Windows' && ! contains(matrix.name, 'Open Watcom') }}
       run: |
         choco install --no-progress ninja ${{ matrix.packages }}
 
     - name: Generate project files
-      run: cmake -S ${{ matrix.src-dir || '.' }} -B ${{ matrix.build-dir || '.' }} ${{ matrix.cmake-args }} -D CMAKE_BUILD_TYPE=${{ matrix.build-config || 'Release' }}
+      run: cmake -S ${{ matrix.src-dir || '.' }} -B ${{ matrix.build-dir || 'build' }} ${{ matrix.cmake-args }} -D CMAKE_BUILD_TYPE=${{ matrix.build-config || 'Release' }}
       env:
         CC: ${{ matrix.compiler }}
         CFLAGS: ${{ matrix.cflags }}
 
     - name: Compile source code
-      run: cmake --build ${{ matrix.build-dir || '.' }} --config ${{ matrix.build-config || 'Release' }}
+      run: cmake --build ${{ matrix.build-dir || 'build' }} --config ${{ matrix.build-config || 'Release' }}
 
     - name: Run test cases
+      if: ${{ ! contains(matrix.name, 'Open Watcom') || ! contains(matrix.cmake-args, 'CMAKE_SYSTEM_NAME') }}
       run: ctest -C Release --output-on-failure --max-width 120
-      working-directory: ${{ matrix.build-dir || '.' }}
+      working-directory: ${{ matrix.build-dir || 'build' }}
 
     - name: Upload build errors
       uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,9 @@ endif()
 
 set(ZLIB_PC ${CMAKE_CURRENT_BINARY_DIR}/zlib.pc)
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zlib.pc.cmakein
-		${ZLIB_PC} @ONLY)
-configure_file(	${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
-		${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
+                ${ZLIB_PC} @ONLY)
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/zconf.h.cmakein
+                ${CMAKE_CURRENT_BINARY_DIR}/zconf.h @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR})
 
 
@@ -150,44 +150,55 @@ if(MINGW)
     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
 endif(MINGW)
 
-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-target_include_directories(zlib PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
 target_include_directories(zlibstatic PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
-set_target_properties(zlib PROPERTIES SOVERSION 1)
 
-if(NOT CYGWIN)
-    # This property causes shared libraries on Linux to have the full version
-    # encoded into their final filename.  We disable this on Cygwin because
-    # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
-    # seems to be the default.
-    #
-    # This has no effect with MSVC, on that platform the version info for
-    # the DLL comes from the resource file win32/zlib1.rc
-    set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
-endif()
+set(ZLIB_BUILD_SHARED_LIB)
+if(NOT(CMAKE_C_COMPILER_ID STREQUAL "OpenWatcom") OR (CMAKE_SYSTEM_NAME MATCHES "Windows|OS2|Windows3x"))
+    set(ZLIB_BUILD_SHARED_LIB 1)
+    add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+    target_include_directories(zlib PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+    set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+    set_target_properties(zlib PROPERTIES SOVERSION 1)
 
-if(UNIX)
-    # On unix-like platforms the library is almost always called libz
-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   if(NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
-     set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
-   endif()
-elseif(BUILD_SHARED_LIBS AND WIN32)
-    # Creates zlib1.dll when building shared library version
-    set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+    if(NOT CYGWIN)
+        # This property causes shared libraries on Linux to have the full version
+        # encoded into their final filename.  We disable this on Cygwin because
+        # it causes cygz-${ZLIB_FULL_VERSION}.dll to be created when cygz.dll
+        # seems to be the default.
+        #
+        # This has no effect with MSVC, on that platform the version info for
+        # the DLL comes from the resource file win32/zlib1.rc
+        set_target_properties(zlib PROPERTIES VERSION ${ZLIB_FULL_VERSION})
+    endif()
+
+    if(UNIX)
+        # On unix-like platforms the library is almost always called libz
+        set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
+        if(NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
+            set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+        endif()
+    elseif(BUILD_SHARED_LIBS AND WIN32)
+        # Creates zlib1.dll when building shared library version
+        set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+    endif()
 endif()
 
 if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
-    install(TARGETS zlib zlibstatic
+    install(TARGETS zlibstatic
         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+    if(ZLIB_BUILD_SHARED_LIB)
+        install(TARGETS zlib
+            RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+            ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+            LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
+    endif()
 endif()
 if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
     install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
@@ -203,21 +214,25 @@ endif()
 # Example binaries
 #============================================================================
 if(ZLIB_BUILD_EXAMPLES)
+    set(ZLIB_EXAMPLES_LINK_LIB zlibstatic)
+    if(ZLIB_BUILD_SHARED_LIB)
+        set(ZLIB_EXAMPLES_LINK_LIB zlib)
+    endif()
     add_executable(example test/example.c)
-    target_link_libraries(example zlib)
+    target_link_libraries(example ${ZLIB_EXAMPLES_LINK_LIB})
     add_test(example example)
 
     add_executable(minigzip test/minigzip.c)
-    target_link_libraries(minigzip zlib)
+    target_link_libraries(minigzip ${ZLIB_EXAMPLES_LINK_LIB})
 
     if(HAVE_OFF64_T)
         add_executable(example64 test/example.c)
-        target_link_libraries(example64 zlib)
+        target_link_libraries(example64 ${ZLIB_EXAMPLES_LINK_LIB})
         set_target_properties(example64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
         add_test(example64 example64)
 
         add_executable(minigzip64 test/minigzip.c)
-        target_link_libraries(minigzip64 zlib)
+        target_link_libraries(minigzip64 ${ZLIB_EXAMPLES_LINK_LIB})
         set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
     endif()
 endif()


### PR DESCRIPTION
add __export modifier if DLL is requested to properly generate import library zlib.lib for OS/2
add CMake cross-compilation build by Open Watcom for 16/32-bit DOS and OS2, 32-bit Windows and 32-bit Linux