### PR TITLE
correct Open Watcom OS/2 build

### DIFF
--- a/zconf.h
+++ b/zconf.h
@@ -375,6 +375,17 @@
 #  endif
 #endif
 
+#if defined(__WATCOMC__)
+#  if defined(ZLIB_DLL)
+#    if defined(__OS2__)
+#      if defined(__SW_BD)
+#        define ZEXPORT   __export
+#        define ZEXPORTVA __export
+#      endif
+#    endif
+#  endif
+#endif
+
 #ifndef ZEXTERN
 #  define ZEXTERN extern
 #endif

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -377,6 +377,17 @@
 #  endif
 #endif
 
+#if defined(__WATCOMC__)
+#  if defined(ZLIB_DLL)
+#    if defined(__OS2__)
+#      if defined(__SW_BD)
+#        define ZEXPORT   __export
+#        define ZEXPORTVA __export
+#      endif
+#    endif
+#  endif
+#endif
+
 #ifndef ZEXTERN
 #  define ZEXTERN extern
 #endif

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -375,6 +375,17 @@
 #  endif
 #endif
 
+#if defined(__WATCOMC__)
+#  if defined(ZLIB_DLL)
+#    if defined(__OS2__)
+#      if defined(__SW_BD)
+#        define ZEXPORT   __export
+#        define ZEXPORTVA __export
+#      endif
+#    endif
+#  endif
+#endif
+
 #ifndef ZEXTERN
 #  define ZEXTERN extern
 #endif


### PR DESCRIPTION
change necessary to build OS/2 DLL 16/32-bit by Open Watcom tools

I separated this change from CI CMake build changes