### PR TITLE
Clean "shorten-64-to-32" warnings

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -755,7 +755,7 @@ unsigned long ZEXPORT crc32_z(unsigned long crc, const unsigned char FAR *buf,
 #endif
 
             /* Initialize the CRC for each braid. */
-            crc0 = crc;
+            crc0 = (z_crc_t)crc;
 #if N > 1
             crc1 = 0;
 #if N > 2
@@ -1022,7 +1022,7 @@ uLong ZEXPORT crc32_combine64(uLong crc1, uLong crc2, z_off64_t len2) {
 #ifdef DYNAMIC_CRC_TABLE
     once(&made, make_crc_table);
 #endif /* DYNAMIC_CRC_TABLE */
-    return multmodp(x2nmodp(len2, 3), crc1) ^ (crc2 & 0xffffffff);
+    return multmodp(x2nmodp(len2, 3), (z_crc_t)crc1) ^ (crc2 & 0xffffffff);
 }
 
 /* ========================================================================= */
@@ -1045,5 +1045,5 @@ uLong ZEXPORT crc32_combine_gen(z_off_t len2) {
 
 /* ========================================================================= */
 uLong ZEXPORT crc32_combine_op(uLong crc1, uLong crc2, uLong op) {
-    return multmodp(op, crc1) ^ (crc2 & 0xffffffff);
+    return multmodp((z_crc_t)op, (z_crc_t)crc1) ^ (crc2 & 0xffffffff);
 }

--- a/deflate.c
+++ b/deflate.c
@@ -713,7 +713,7 @@ int ZEXPORT deflateSetHeader(z_streamp strm, gz_headerp head) {
 int ZEXPORT deflatePending(z_streamp strm, unsigned *pending, int *bits) {
     if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
     if (pending != Z_NULL)
-        *pending = strm->state->pending;
+        *pending = (unsigned)strm->state->pending;
     if (bits != Z_NULL)
         *bits = strm->state->bi_valid;
     return Z_OK;
@@ -917,7 +917,7 @@ local void flush_pending(z_streamp strm) {
     deflate_state *s = strm->state;
 
     _tr_flush_bits(s);
-    len = s->pending;
+    len = (unsigned)s->pending;
     if (len > strm->avail_out) len = strm->avail_out;
     if (len == 0) return;
 
@@ -939,7 +939,7 @@ local void flush_pending(z_streamp strm) {
     do { \
         if (s->gzhead->hcrc && s->pending > (beg)) \
             strm->adler = crc32(strm->adler, s->pending_buf + (beg), \
-                                s->pending - (beg)); \
+                                (unsigned)s->pending - (beg)); \
     } while (0)
 
 /* ========================================================================= */
@@ -1074,7 +1074,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
             }
             if (s->gzhead->hcrc)
                 strm->adler = crc32(strm->adler, s->pending_buf,
-                                    s->pending);
+                                    (unsigned)s->pending);
             s->gzindex = 0;
             s->status = EXTRA_STATE;
         }
@@ -1082,13 +1082,13 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
     if (s->status == EXTRA_STATE) {
         if (s->gzhead->extra != Z_NULL) {
             ulg beg = s->pending;   /* start of bytes to update crc */
-            uInt left = (s->gzhead->extra_len & 0xffff) - s->gzindex;
+            uInt left = (s->gzhead->extra_len & 0xffff) - (unsigned)s->gzindex;
             while (s->pending + left > s->pending_buf_size) {
-                uInt copy = s->pending_buf_size - s->pending;
+                uInt copy = (unsigned)(s->pending_buf_size - s->pending);
                 zmemcpy(s->pending_buf + s->pending,
                         s->gzhead->extra + s->gzindex, copy);
                 s->pending = s->pending_buf_size;
-                HCRC_UPDATE(beg);
+                HCRC_UPDATE((unsigned)beg);
                 s->gzindex += copy;
                 flush_pending(strm);
                 if (s->pending != 0) {
@@ -1101,7 +1101,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
             zmemcpy(s->pending_buf + s->pending,
                     s->gzhead->extra + s->gzindex, left);
             s->pending += left;
-            HCRC_UPDATE(beg);
+            HCRC_UPDATE((unsigned)beg);
             s->gzindex = 0;
         }
         s->status = NAME_STATE;
@@ -1112,7 +1112,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
             int val;
             do {
                 if (s->pending == s->pending_buf_size) {
-                    HCRC_UPDATE(beg);
+                    HCRC_UPDATE((unsigned)beg);
                     flush_pending(strm);
                     if (s->pending != 0) {
                         s->last_flush = -1;
@@ -1123,7 +1123,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
                 val = s->gzhead->name[s->gzindex++];
                 put_byte(s, val);
             } while (val != 0);
-            HCRC_UPDATE(beg);
+            HCRC_UPDATE((unsigned)beg);
             s->gzindex = 0;
         }
         s->status = COMMENT_STATE;
@@ -1134,7 +1134,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
             int val;
             do {
                 if (s->pending == s->pending_buf_size) {
-                    HCRC_UPDATE(beg);
+                    HCRC_UPDATE((unsigned)beg);
                     flush_pending(strm);
                     if (s->pending != 0) {
                         s->last_flush = -1;
@@ -1145,7 +1145,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
                 val = s->gzhead->comment[s->gzindex++];
                 put_byte(s, val);
             } while (val != 0);
-            HCRC_UPDATE(beg);
+            HCRC_UPDATE((unsigned)beg);
         }
         s->status = HCRC_STATE;
     }
@@ -1629,7 +1629,7 @@ local block_state deflate_stored(deflate_state *s, int flush) {
      * this is 32K. This can be as small as 507 bytes for memLevel == 1. For
      * large input and output buffers, the stored block size will be larger.
      */
-    unsigned min_block = MIN(s->pending_buf_size - 5, s->w_size);
+    unsigned min_block = MIN((unsigned)s->pending_buf_size - 5, s->w_size);
 
     /* Copy as many min_block or larger stored blocks directly to next_out as
      * possible. If flushing, copy the remaining available input to next_out as
@@ -1649,7 +1649,7 @@ local block_state deflate_stored(deflate_state *s, int flush) {
             break;
             /* maximum stored block length that will fit in avail_out: */
         have = s->strm->avail_out - have;
-        left = s->strstart - s->block_start;    /* bytes left in window */
+        left = s->strstart - (unsigned)s->block_start;    /* bytes left in window */
         if (len > (ulg)left + s->strm->avail_in)
             len = left + s->strm->avail_in;     /* limit len to the input */
         if (len > have)
@@ -1755,7 +1755,7 @@ local block_state deflate_stored(deflate_state *s, int flush) {
         return block_done;
 
     /* Fill the window with any remaining input. */
-    have = s->window_size - s->strstart;
+    have = (unsigned)s->window_size - s->strstart;
     if (s->strm->avail_in > have && s->block_start >= (long)s->w_size) {
         /* Slide the window down. */
         s->block_start -= s->w_size;
@@ -1784,9 +1784,9 @@ local block_state deflate_stored(deflate_state *s, int flush) {
      */
     have = (s->bi_valid + 42) >> 3;         /* number of header bytes */
         /* maximum stored block length that will fit in pending: */
-    have = MIN(s->pending_buf_size - have, MAX_STORED);
+    have = MIN((unsigned)s->pending_buf_size - have, MAX_STORED);
     min_block = MIN(have, s->w_size);
-    left = s->strstart - s->block_start;
+    left = s->strstart - (unsigned)s->block_start;
     if (left >= min_block ||
         ((left || flush == Z_FINISH) && flush != Z_NO_FLUSH &&
          s->strm->avail_in == 0 && left <= have)) {


### PR DESCRIPTION
I got "shorten-64-to-32" warning when using clang compiler and I try to fix them.
I added explicit conversion to remove this warning. I think it helps improve the code quality.