### PR TITLE
cmake: don't use --version-script on static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 if(UNIX)
     # On unix-like platforms the library is almost always called libz
    set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
-   if(NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX))
+   if(BUILD_SHARED_LIBS AND (NOT APPLE AND NOT(CMAKE_SYSTEM_NAME STREQUAL AIX)))
      set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
    endif()
 elseif(BUILD_SHARED_LIBS AND WIN32)


### PR DESCRIPTION
According to the documentation [1] it's only useful for shared libraries. With recent Android NDK this leads to linking issues with gz_intmax similar to #856. In autotools it's only set with LDSHARED.

[1]https://ftp.gnu.org/old-gnu/Manuals/ld-2.9.1/html_chapter/ld_3.html