### PR TITLE
Fix Uninitialized variable

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -685,6 +685,7 @@ extern unzFile ZEXPORT unzOpen2_64(const void *path,
         zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
         zlib_filefunc64_32_def_fill.ztell32_file = NULL;
         zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        zlib_filefunc64_32_def_fill.zopen32_file = NULL;
         return unzOpenInternal(path, &zlib_filefunc64_32_def_fill, 1);
     }
     else

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1136,6 +1136,7 @@ extern zipFile ZEXPORT zipOpen2_64(const void *pathname, int append, zipcharpc* 
         zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
         zlib_filefunc64_32_def_fill.ztell32_file = NULL;
         zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        zlib_filefunc64_32_def_fill.zopen32_file = NULL;
         return zipOpen3(pathname, append, globalcomment, &zlib_filefunc64_32_def_fill);
     }
     else


### PR DESCRIPTION
In `minizip/unzip:684` and `minizip/unzip:1135` , a `zlib_filefunc64_32_def` is being created and passed to the `zipOpen3` function. During this process, the code falls to initiallze the `zopen32_file` member.