### PR TITLE
contrib/minizip: replace obsolete autotools macro AC_HELP_STRING by AS_HELP_STRING

### DIFF
--- a/contrib/minizip/configure.ac
+++ b/contrib/minizip/configure.ac
@@ -7,7 +7,7 @@ AM_INIT_AUTOMAKE([foreign])
 LT_INIT
 
 AC_MSG_CHECKING([whether to build example programs])
-AC_ARG_ENABLE([demos], AC_HELP_STRING([--enable-demos], [build example programs]))
+AC_ARG_ENABLE([demos], AS_HELP_STRING([--enable-demos], [build example programs]))
 AM_CONDITIONAL([COND_DEMOS], [test "$enable_demos" = yes])
 if test "$enable_demos" = yes
 then


### PR DESCRIPTION
## Description

Reference: [https://www.gnu.org/software/autoconf/manual/autoconf-2.72/autoconf.html#Obsolete-Macros](https://www.gnu.org/software/autoconf/manual/autoconf-2.72/autoconf.html#index-AC_005fHELP_005fSTRING-1)

The macro `AC_HELP_STRING` is considered obsolete and should be replaced by `AS_HELP_STRING`.

Current warning when running `autoreconf --install --include=$(aclocal --print-ac-dir)`:
```txt
configure.ac:10: warning: The macro 'AC_HELP_STRING' is obsolete.
configure.ac:10: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:10: the top levelconfigure.ac:10: warning: The macro 'AC_HELP_STRING' is obsolete.
configure.ac:10: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:10: the top level
```

## Testing

I reran `autoreconf --install --include=$(aclocal --print-ac-dir)` and there is no warning related `AC_HELP_STRING`.
```txt
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac,
libtoolize: and rerunning libtoolize and aclocal.
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
configure.ac:10: warning: The macro 'AC_HELP_STRING' is obsolete.
configure.ac:10: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
configure.ac:10: the top level
configure.ac:7: installing './compile'
configure.ac:7: installing './config.guess'
configure.ac:7: installing './config.sub'
configure.ac:6: installing './install-sh'
configure.ac:6: installing './missing'
Makefile.am: installing './depcomp'
```
No change in the generated `./configure` script.