### PR TITLE
Fix llvm cross build for win on arm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,10 +139,10 @@ if(MINGW)
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)
     endif()
-    string(REPLACE " " ";" ZLIB_RC_COMPILER_LIST ${CMAKE_RC_COMPILER})
+    string(REPLACE " " ";" ZLIB_CMAKE_RC_FLAGS_LIST ${CMAKE_RC_FLAGS})
 
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                       COMMAND ${ZLIB_RC_COMPILER_LIST}
+                       COMMAND ${CMAKE_RC_COMPILER} ${ZLIB_CMAKE_RC_FLAGS_LIST}
                             -D GCC_WINDRES
                             -I ${CMAKE_CURRENT_SOURCE_DIR}
                             -I ${CMAKE_CURRENT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,9 +139,10 @@ if(MINGW)
     if(NOT CMAKE_RC_COMPILER)
         set(CMAKE_RC_COMPILER windres.exe)
     endif()
+    string(REPLACE " " ";" ZLIB_RC_COMPILER_LIST ${CMAKE_RC_COMPILER})
 
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                       COMMAND ${CMAKE_RC_COMPILER} ${CMAKE_RC_FLAGS}
+                       COMMAND ${ZLIB_RC_COMPILER_LIST}
                             -D GCC_WINDRES
                             -I ${CMAKE_CURRENT_SOURCE_DIR}
                             -I ${CMAKE_CURRENT_BINARY_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if(MINGW)
     endif()
 
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj
-                       COMMAND ${CMAKE_RC_COMPILER}
+                       COMMAND ${CMAKE_RC_COMPILER} ${CMAKE_RC_FLAGS}
                             -D GCC_WINDRES
                             -I ${CMAKE_CURRENT_SOURCE_DIR}
                             -I ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
I try to use clang for cross-compiling for the win on the arm.

The problem is that llvm-windres, by default, uses the false build architecture.