### PR TITLE
Include build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 /minigzipsh
 /zlib.pc
 /configure.log
+/build
 
 .DS_Store
 .vs


### PR DESCRIPTION
Library is usually compiled into a folder /build . Upon cration of this folder and subsequent compilation, git starts showing entire folder as untracked change. It would be better if this default build directory is included in the .gitignore file.