### PR TITLE
Account for a forced stored block in deflateUsed()

### DIFF
--- a/trees.c
+++ b/trees.c
@@ -185,6 +185,8 @@ local void bi_windup(deflate_state *s) {
         put_byte(s, (Byte)s->bi_buf);
     }
     s->bi_used = ((s->bi_valid - 1) & 7) + 1;
+    if (s->level == 0)
+        s->bi_used += 5; /* forced stored block */
     s->bi_buf = 0;
     s->bi_valid = 0;
 #ifdef ZLIB_DEBUG

--- a/zlib.h
+++ b/zlib.h
@@ -796,8 +796,9 @@ ZEXTERN int ZEXPORT deflateUsed(z_streamp strm,
 /*
      deflateUsed() returns in *bits the most recent number of deflate bits used
    in the last byte when flushing to a byte boundary. The result is in 1..8, or
-   0 if there has not yet been a flush. This helps determine the location of
-   the last bit of a deflate stream.
+   0 if there has not yet been a flush. When compression is disabled, the result
+   includes the additional 5 bits of a stored block needed during the flush.
+   This helps determine the location of the last bit of a deflate stream.
 
      deflateUsed returns Z_OK if success, or Z_STREAM_ERROR if the source
    stream state was inconsistent.


### PR DESCRIPTION
See https://github.com/madler/zlib/issues/189#issuecomment-2205172650 and https://github.com/varnishcache/varnish-cache/pull/3873#issuecomment-2205637791

With `deflateUsed()` as it currently stands, I have not been able to make all of our use cases work in Varnish Cache without poking at the deflate state. With this patch I can reliably collect the last bit position of the last deflate block in a GZIP stream, as far as our somewhat extensive test suite goes.

It also matched the last bit position collected by the fork we currently rely on with a corpus of more than 170000 files.