### PR TITLE
Fix #999: fix compiling failure in Tornado2.2 with no stdint.h

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -25,7 +25,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdint.h>
 #include <time.h>
 #include "zlib.h"
 #include "zip.h"
@@ -1646,7 +1645,7 @@ extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void* buf, unsigned i
     else
 #endif
     {
-      zi->ci.stream.next_in = (Bytef*)(uintptr_t)buf;
+      zi->ci.stream.next_in = (Bytef*)(ZPOS64_T)buf;
       zi->ci.stream.avail_in = len;
 
       while ((err==ZIP_OK) && (zi->ci.stream.avail_in>0))


### PR DESCRIPTION
There are only one `uintptr_t` in `minizip`, which can be replace by ZPOS64_T in order to fix the compiling failure where has no `stdint.h`.