### PR TITLE
Ensure possible padding bytes are initialized

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -101,6 +101,7 @@ local gzFile gz_open(const void *path, int fd, const char *mode) {
     state = (gz_statep)malloc(sizeof(gz_state));
     if (state == NULL)
         return NULL;
+    memset(state, 0, sizeof(gz_state));
     state->size = 0;            /* no buffers allocated yet */
     state->want = GZBUFSIZE;    /* requested buffer size */
     state->msg = NULL;          /* no error message yet */


### PR DESCRIPTION
Microsoft's static analysis tool found a vulnerability from possible info leakage from uninitialized padding bytes in this struct, which I changed in [microsoft/cmake](https://github.com/microsoft/cmake). Pushing this change upstream so it can be added to [kitware/cmake](https://github.com/Kitware/CMake).