### PR TITLE
Properly avoid defining z_const.

### DIFF
--- a/zconf.h
+++ b/zconf.h
@@ -235,10 +235,12 @@
 #  endif
 #endif
 
-#if defined(ZLIB_CONST) && !defined(z_const)
-#  define z_const const
-#else
-#  define z_const
+#ifndef z_const
+#  ifdef ZLIB_CONST
+#    define z_const const
+#  else
+#    define z_const
+#  endif
 #endif
 
 #ifdef Z_SOLO

--- a/zconf.h.cmakein
+++ b/zconf.h.cmakein
@@ -237,10 +237,12 @@
 #  endif
 #endif
 
-#if defined(ZLIB_CONST) && !defined(z_const)
-#  define z_const const
-#else
-#  define z_const
+#ifndef z_const
+#  ifdef ZLIB_CONST
+#    define z_const const
+#  else
+#    define z_const
+#  endif
 #endif
 
 #ifdef Z_SOLO

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -235,10 +235,12 @@
 #  endif
 #endif
 
-#if defined(ZLIB_CONST) && !defined(z_const)
-#  define z_const const
-#else
-#  define z_const
+#ifndef z_const
+#  ifdef ZLIB_CONST
+#    define z_const const
+#  else
+#    define z_const
+#  endif
 #endif
 
 #ifdef Z_SOLO


### PR DESCRIPTION
If the `z_const` macro is already defined, then we want to avoid re-defining it. Only the way it was written, it would attempt a `#define` anyway, which most certainly would just generate a warning.

Here is a PR to clean that up.