### PR TITLE
Correct command line options for xlc and ar on AIX for 64 bit mode

### DIFF
--- a/configure
+++ b/configure
@@ -365,7 +365,12 @@ else
   AIX*)  # Courtesy of dbakker@arrayasolutions.com
              SFLAGS=${CFLAGS-"-O -qmaxmem=8192"}
              CFLAGS=${CFLAGS-"-O -qmaxmem=8192"}
-             LDSHARED=${LDSHARED-"xlc -G"} ;;
+             LDSHARED=${LDSHARED-"xlc -G"}
+             if test $build64 -eq 1; then
+                 CFLAGS="${CFLAGS} -q64"
+                 SFLAGS="${SFLAGS} -q64"
+                 ARFLAGS="-X64 ${ARFLAGS}"
+             fi ;;
   # send working options for other systems to zlib@gzip.org
   *)         SFLAGS=${CFLAGS-"-O"}
              CFLAGS=${CFLAGS-"-O"}


### PR DESCRIPTION
Current version does not set correct options for xlc and ar on AIX when 64 bit build is selected with option --64 for configure. Proposed patch fixes that issue.
