### PR TITLE
Correct readme.txt VS2022 sollution path

### DIFF
--- a/contrib/vstudio/readme.txt
+++ b/contrib/vstudio/readme.txt
@@ -43,7 +43,7 @@ Build instructions for Visual Studio 2015 (32 bits or 64 bits)
 Build instructions for Visual Studio 2022 (64 bits)
 --------------------------------------------------------------
 - Decompress current zlib, including all contrib/* files
-- Open contrib\vstudio\vc143\zlibvc.sln with Microsoft Visual C++ 2022
+- Open contrib\vstudio\vc17\zlibvc.sln with Microsoft Visual C++ 2022
 
 
 


### PR DESCRIPTION
I guess that it is wrong in the readme file because it does not match with the existing folder structure