### PR TITLE
[configure][bug-fix] Add existence check for compiler

### DIFF
--- a/configure
+++ b/configure
@@ -184,6 +184,14 @@ else
   cc=${CC}
 fi
 
+echo "Checking for compiler existence" >> configure.log
+if which $cc >/dev/null 2>&1; then
+  :
+else
+  echo "Failed to find an installed compiler." | tee -a configure.log
+  leave 1
+fi
+
 case "$cc" in
   *gcc*) gcc=1 ;;
   *clang*) gcc=1 ;;


### PR DESCRIPTION
Issue: #1023

Add a configure test that verifies the presence of the compiler before we continue on using it in the following tests. If missing return an indicative error to the user.