### PR TITLE
Correct the value of rest_read_compressed when decompressing an encrypted zip

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -1498,6 +1498,7 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method,
             zdecode(s->keys,s->pcrc_32_tab,source[i]);
 
         s->pfile_in_zip_read->pos_in_zipfile+=12;
+        s->pfile_in_zip_read->rest_read_compressed-=12;
         s->encrypted=1;
     }
 #    endif


### PR DESCRIPTION
Chromium had this in a downstream patch: https://chromium-review.googlesource.com/c/chromium/src/+/1161109