### PR TITLE
Fix Visual Studio 2022 projects (create zconf.h)

### DIFF
--- a/contrib/vstudio/readme.txt
+++ b/contrib/vstudio/readme.txt
@@ -2,7 +2,7 @@ Building instructions for the DLL versions of Zlib 1.3.1.1
 ========================================================
 
 This directory contains projects that build zlib and minizip using
-Microsoft Visual C++ 9.0/10.0.
+Microsoft Visual C++ 9.0/17.0.
 
 You don't need to build these projects yourself. You can download the
 binaries from:
@@ -40,10 +40,10 @@ Build instructions for Visual Studio 2015 (32 bits or 64 bits)
 - Decompress current zlib, including all contrib/* files
 - Open contrib\vstudio\vc14\zlibvc.sln with Microsoft Visual C++ 2015
 
-Build instructions for Visual Studio 2022 (64 bits)
+Build instructions for Visual Studio 2022 (32 bits or 64 bits)
 --------------------------------------------------------------
 - Decompress current zlib, including all contrib/* files
-- Open contrib\vstudio\vc143\zlibvc.sln with Microsoft Visual C++ 2022
+- Open contrib\vstudio\vc17\zlibvc.sln with Microsoft Visual C++ 2022
 
 
 

--- a/contrib/vstudio/vc17/testzlib.vcxproj
+++ b/contrib/vstudio/vc17/testzlib.vcxproj
@@ -467,6 +467,16 @@
     <ClCompile Include="..\..\..\uncompr.c" />
     <ClCompile Include="..\..\..\zutil.c" />
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\..\zconf.h.in">
+      <FileType>Document</FileType>
+      <Command>if not exist ..\..\..\zconf.h (
+		echo copy "%(FullPath)" ..\..\..\zconf.h
+		copy "%(FullPath)" ..\..\..\zconf.h)
+      </Command>
+      <Outputs>..\..\..\zconf.h;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/contrib/vstudio/vc17/testzlibdll.vcxproj
+++ b/contrib/vstudio/vc17/testzlibdll.vcxproj
@@ -403,6 +403,16 @@
       <Project>{8fd826f8-3739-44e6-8cc8-997122e53b8d}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\..\zconf.h.in">
+      <FileType>Document</FileType>
+      <Command>if not exist ..\..\..\zconf.h (
+		echo copy "%(FullPath)" ..\..\..\zconf.h
+		copy "%(FullPath)" ..\..\..\zconf.h)
+      </Command>
+      <Outputs>..\..\..\zconf.h;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/contrib/vstudio/vc17/zlibstat.vcxproj
+++ b/contrib/vstudio/vc17/zlibstat.vcxproj
@@ -596,6 +596,16 @@
   <ItemGroup>
     <None Include="zlibvc.def" />
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\..\zconf.h.in">
+      <FileType>Document</FileType>
+      <Command>if not exist ..\..\..\zconf.h (
+		echo copy "%(FullPath)" ..\..\..\zconf.h
+		copy "%(FullPath)" ..\..\..\zconf.h)
+      </Command>
+      <Outputs>..\..\..\zconf.h;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/contrib/vstudio/vc17/zlibvc.vcxproj
+++ b/contrib/vstudio/vc17/zlibvc.vcxproj
@@ -869,6 +869,16 @@
     <ClInclude Include="..\..\..\zlib.h" />
     <ClInclude Include="..\..\..\zutil.h" />
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="..\..\..\zconf.h.in">
+      <FileType>Document</FileType>
+      <Command>if not exist ..\..\..\zconf.h (
+		echo copy "%(FullPath)" ..\..\..\zconf.h
+		copy "%(FullPath)" ..\..\..\zconf.h)
+      </Command>
+      <Outputs>..\..\..\zconf.h;%(Outputs)</Outputs>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>


### PR DESCRIPTION
This is a minimalistic fix for Visual Studio 2022 only.
Successfully builds for all Intel configurations.
It could be enhanced - for example, _.filters_ files added to make project trees look better in IDE.

Please see if anything needs to be changed.

Additional remarks - separate issues might be created.
1. Other IDEs such as Delphi and Borland also would need to be fixed.
2. Projects for earlier versions of Visual Studio can be fixed similarly. Though most configurations, if not all, could be reduced - maybe to just one. In this case, _Windows SDK Version_ and _Platform Toolset_ might be requested to be changed or updated on the first opening of the solution/project.
3. Over time, project files collected a bit of garbage and it should be cleaned. At least, `ReleaseWithoutAsm` configuration; currently there is no single _*.asm_ file in the source code.
4. When building a solution, Visual Studio may use several threads to compile multiple projects simultaneously. There is a non-zero probability of copy operation to fail (simply repeat the build, because at least one thread had created `zconf.h`). But, this is rare, and usually only the library project would be needed, not the provided solution.