### PR TITLE
Fix Ada bindings on x64

### DIFF
--- a/contrib/ada/zlib-thin.adb
+++ b/contrib/ada/zlib-thin.adb
@@ -12,7 +12,8 @@ package body ZLib.Thin is
 
    ZLIB_VERSION  : constant Chars_Ptr := zlibVersion;
 
-   Z_Stream_Size : constant Int := Z_Stream'Size / System.Storage_Unit;
+   Dummy : Z_Stream;
+   Z_Stream_Size : constant Int := Dummy'Size / System.Storage_Unit;
 
    --------------
    -- Avail_In --


### PR DESCRIPTION
This fixes a problem with calculating the size of Z_Stream which leads to a zlib initialization error on x64. What needs to be calculated is the object size, and not the size of the type. For 32-Bit targets it does not matter, but for 64-Bit there is a difference, due to padding bytes for alignment. On GNAT we could use the Object_Size attribute instead, but this is not supported by other Ada compilers.