### PR TITLE
Windows: fix incorrect header inclusion

### DIFF
--- a/zconf.h
+++ b/zconf.h
@@ -436,11 +436,11 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#ifdef HAVE_UNISTD_H    /* may be set to #if 1 by ./configure */
+#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#ifdef HAVE_STDARG_H    /* may be set to #if 1 by ./configure */
+#if defined(HAVE_STDARG_H) && HAVE_STDARG_H
 #  define Z_HAVE_STDARG_H
 #endif
 


### PR DESCRIPTION
Thanks for the great library ❤️! This PR fixes #787, which is FFmpeg build issue, by preventing incorrect inclusion of headers when the HAVE_ macros are defined but set to 0. On Windows, the unix headers aren't available, which was causing this condition and resulting in FFmpeg build failures.

This is originally based on a patch used downstream: https://github.com/microsoft/vcpkg/blob/master/ports/zlib/0001-Prevent-invalid-inclusions-when-HAVE_-is-set-to-0.patch

I cleaned it up for incorporation in https://github.com/wingtk/gvsbuild/pull/1533

The original patch adds two levels of checking:
1. `~(~HAVE_UNISTD_H + 0) == 0 && ~(~HAVE_UNISTD_H + 1) == 1`, while this is a clever bit manipulation trick, it also isn't very readable. 
b. Second check: `HAVE_UNISTD_H != 0`. This is a simpler fallback check that ensures the value isn't 0

This patch ensures that Z_HAVE_UNISTD_H and Z_HAVE_STDARG_H are only defined when:
1. The respective HAVE_ macro is properly defined
2. AND its value is actually meaningful (not 0)

I think this approach is more readable, and achieves the same goal of only defining `Z_HAVE_UNISTD_H` when `HAVE_UNISTD_H` are both defined and set to a true value.