### PR TITLE
inflate.c: fix potential overflow in inflatePrime

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -232,7 +232,7 @@ int ZEXPORT inflatePrime(z_streamp strm, int bits, int value) {
         state->bits = 0;
         return Z_OK;
     }
-    if (bits > 16 || state->bits + (uInt)bits > 32) return Z_STREAM_ERROR;
+    if (bits > 16 || state->bits + (uInt)bits >= 32) return Z_STREAM_ERROR;
     value &= (1L << bits) - 1;
     state->hold += (unsigned)value << state->bits;
     state->bits += (uInt)bits;


### PR DESCRIPTION
The condition `state->bits + (uInt)bits > 32` was replaced with `state->bits + (uInt)bits >= 32` to prevent potential overflow when shifting `value` by `state->bits`. A shift equal to or greater than the size of the data type (32 bits) can lead to undefined behavior.

This change ensures that the sum of `state->bits` and `bits` never reaches 32, avoiding the risk of overflow in the expression `(unsigned)value << state->bits`.

While the scenario leading to overflow is unlikely in practice due to the constraints of the calling function `inflatePrime`, I recommend applying this change to improve code robustness and adhere to safe coding practices. This is a preventive measure to eliminate any potential risks in edge cases.


Triggers found by static analyzer Svace.

Signed-off-by: Anton Moryakov <ant.v.moryakov@gmail.com>