### PR TITLE
Added CI worker for native S390X

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         include:
           - name: Ubuntu GCC
+            enabled: true
             os: ubuntu-latest
             compiler: gcc
             cflags: -Wall -Wextra
@@ -16,6 +17,7 @@ jobs:
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
           - name: Ubuntu GCC -O3
+            enabled: true
             os: ubuntu-latest
             compiler: gcc
             cflags: -O3 -Wall -Wextra
@@ -23,6 +25,7 @@ jobs:
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
           - name: Ubuntu Clang
+            enabled: true
             os: ubuntu-latest
             compiler: clang
             cflags: -Wall -Wextra
@@ -30,6 +33,7 @@ jobs:
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
           - name: Ubuntu Clang Debug
+            enabled: true
             os: ubuntu-latest
             compiler: clang
             cflags: -Wall -Wextra
@@ -38,6 +42,7 @@ jobs:
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
           - name: Windows MSVC Win32
+            enabled: true
             os: windows-latest
             compiler: cl
             cflags: /W3
@@ -45,6 +50,7 @@ jobs:
             pkgtgt: PACKAGE
 
           - name: Windows MSVC Win64
+            enabled: true
             os: windows-latest
             compiler: cl
             cflags: /W3
@@ -52,6 +58,7 @@ jobs:
             pkgtgt: PACKAGE
 
           - name: Windows GCC
+            enabled: true
             os: windows-latest
             compiler: gcc
             cflags: -Wall -Wextra
@@ -59,6 +66,7 @@ jobs:
             pkgtgt: package
 
           - name: macOS Clang
+            enabled: true
             os: macos-latest
             compiler: clang
             cflags: -Wall -Wextra
@@ -66,44 +74,59 @@ jobs:
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
           - name: macOS GCC
+            enabled: true
             os: macos-latest
             compiler: gcc-12
             cflags: -Wall -Wextra
             pkgtgt: package
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
+          - name: S390X Native GCC
+            enabled: ${{ github.repository == 'fneddy/zlib' && 'true' || false }}
+            os: ${{ github.repository == 'fneddy/zlib' && 'S390X' || 'ubuntu-latest' }}
+            compiler: gcc
+            cflags: -Wall -Wextra
+            cmake-args: -DMINIZIP_ENABLE_BZIP2=OFF
+            pkgtgt: package
+
     steps:
     - name: Checkout repository
+      if: matrix.enabled
       uses: actions/checkout@v4
 
     - name: Install packages (Windows)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && matrix.enabled
       run: |
         choco install --no-progress ninja
 
     - name: Install packages (Linux)
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' &&  matrix.os != 'S390X' && matrix.enabled
       run: |
         sudo apt install libbz2-dev
+
     - name: Generate project files
+      if: matrix.enabled
       run: cmake -S . -B ../build ${{ matrix.cmake-args }} -D CMAKE_BUILD_TYPE=${{ matrix.build-config || 'Release' }} -DZLIB_BUILD_MINIZIP=ON
       env:
         CC: ${{ matrix.compiler }}
         CFLAGS: ${{ matrix.cflags }}
 
     - name: Compile source code
+      if: matrix.enabled
       run: cmake --build ../build --config ${{ matrix.build-config || 'Release' }}
 
     - name: Run test cases
+      if: matrix.enabled
       run: ctest -C Release --output-on-failure --max-width 120
       working-directory: ../build
 
     - name: create packages
+      if: matrix.enabled
       run: cmake --build ../build --config ${{ matrix.build-config || 'Release' }} -t ${{ matrix.pkgtgt }}
 
     - name: Upload build errors
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() && matrix.enabled == true
       with:
         name: ${{ matrix.name }} (cmake)
         path: |

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -9,12 +9,14 @@ jobs:
       matrix:
         include:
           - name: Ubuntu GCC
+            enabled: true
             os: ubuntu-latest
             compiler: gcc
             configure-args: --warn
 
           # Test out of source builds
           - name: Ubuntu GCC OSB
+            enabled: true
             os: ubuntu-latest
             compiler: gcc
             configure-args: --warn
@@ -22,6 +24,7 @@ jobs:
             src-dir: ../zlib
 
           - name: Ubuntu GCC ARM SF
+            enabled: true
             os: ubuntu-latest
             compiler: arm-linux-gnueabi-gcc
             configure-args: --warn
@@ -30,6 +33,7 @@ jobs:
             qemu-run: qemu-arm -L /usr/arm-linux-gnueabi
 
           - name: Ubuntu GCC ARM HF
+            enabled: true
             os: ubuntu-latest
             compiler: arm-linux-gnueabihf-gcc
             configure-args: --warn
@@ -38,6 +42,7 @@ jobs:
             qemu-run: qemu-arm -L /usr/arm-linux-gnueabihf
 
           - name: Ubuntu GCC AARCH64
+            enabled: true
             os: ubuntu-latest
             compiler: aarch64-linux-gnu-gcc
             configure-args: --warn
@@ -46,6 +51,7 @@ jobs:
             qemu-run: qemu-aarch64 -L /usr/aarch64-linux-gnu
 
           - name: Ubuntu GCC PPC
+            enabled: true
             os: ubuntu-latest
             compiler: powerpc-linux-gnu-gcc
             configure-args: --warn --static
@@ -56,6 +62,7 @@ jobs:
             ldflags: -static
 
           - name: Ubuntu GCC PPC64
+            enabled: true
             os: ubuntu-latest
             compiler: powerpc64-linux-gnu-gcc
             configure-args: --warn --static
@@ -66,6 +73,7 @@ jobs:
             ldflags: -static
 
           - name: Ubuntu GCC PPC64LE
+            enabled: true
             os: ubuntu-latest
             compiler: powerpc64le-linux-gnu-gcc
             configure-args: --warn
@@ -73,7 +81,9 @@ jobs:
             packages: qemu-system qemu-user gcc-powerpc64le-linux-gnu libc-dev-ppc64el-cross
             qemu-run: qemu-ppc64le -L /usr/powerpc64le-linux-gnu
 
+          # if on base repo use the native workflow runner, else QEMU
           - name: Ubuntu GCC S390X
+            enabled: true
             os: ubuntu-latest
             compiler: s390x-linux-gnu-gcc
             configure-args: --warn --static
@@ -83,27 +93,37 @@ jobs:
             cflags: -static
             ldflags: -static
 
+          - name: Native S390X GCC
+            enabled: ${{ github.repository == 'fneddy/zlib' && 'true' || false }}
+            os: ${{ github.repository == 'fneddy/zlib' && 'S390X' || 'ubuntu-latest' }}
+            compiler: gcc
+            configure-args: --warn
+
           - name: macOS GCC
+            enabled: true
             os: macos-latest
             compiler: gcc-12
             configure-args: --warn
 
           - name: macOS Clang
+            enabled: true
             os: macos-latest
             compiler: clang
             configure-args: --warn
 
     steps:
     - name: Checkout repository
+      if: matrix.enabled
       uses: actions/checkout@v4
 
     - name: Install packages (Ubuntu)
-      if: runner.os == 'Linux' && matrix.packages
+      if: runner.os == 'Linux' && matrix.packages && matrix.enabled
       run: |
         sudo apt-get update
         sudo apt-get install -y ${{ matrix.packages }}
 
     - name: Generate project files
+      if: matrix.enabled
       run: |
         [ -d ${{ matrix.build-dir || '.' }} ] || mkdir ${{ matrix.build-dir || '.' }}
         cd ${{ matrix.build-dir || '.' }}
@@ -115,10 +135,12 @@ jobs:
         CHOST: ${{ matrix.chost }}
 
     - name: Compile source code
+      if: matrix.enabled
       run: make -j2
       working-directory: ${{ matrix.build-dir }}
 
     - name: Run test cases
+      if: matrix.enabled
       run: |
         make test
         make cover
@@ -128,7 +150,7 @@ jobs:
 
     - name: Upload build errors
       uses: actions/upload-artifact@v4
-      if: failure()
+      if: failure() && matrix.enabled
       with:
         name: ${{ matrix.name }} (configure)
         path: |

--- a/contrib/README.contrib
+++ b/contrib/README.contrib
@@ -55,3 +55,6 @@ untgz/      by Pedro A. Aranda Gutierrez <paag@tid.es>
 vstudio/    by Gilles Vollant <info@winimage.com>
         Building a minizip-enhanced zlib with Microsoft Visual Studio
         Includes vc11 from kreuzerkrieg and vc12 from davispuh
+
+s390x/      by Eduard Stefes <eduard.stefes@ibm.com>
+        Scripts to create S390X github action workers.

--- a/contrib/s390x/README.md
+++ b/contrib/s390x/README.md
@@ -1,0 +1,68 @@
+# General Notes
+
+> [!NOTE]  
+> This is a modified and simplified copy of the s390x self-hosted action runner scripts from here:
+> - https://github.com/zlib-ng/zlib-ng/tree/a0fa24710c8faa1a746a20cfd5c7c24571e15ca4/arch/s390/self-hosted-builder
+> - https://github.com/anup-kodlekere/gaplib
+>
+> **This code does NOT setup ephemeral workers!!**. It means that the worker context will be reused between CI runs and never be destroyed. 
+>
+> The implications are:
+> - one needs to check a PR that does not leak the /etc/actions_runner_conf
+> - one needs to check a PR that it does not alter the system in a persistent way
+> - one needs to check a PR that it does not access any file outside of the build folder
+>
+> To create ephemeral workers we need to setup a token request process similar like zlib-ng has done. But such a process implies that the worker maintainer needs, not just commit, but administration rights to the repository.
+
+## Self Hosted Runner
+
+Given complexity of Vector and DFLTCC machine instruction, it is not clear whether QEMU TCG will ever support it. At the time of writing, one has to have access to an IBM z15+ VM or LPAR in order to test the support. Since DFLTCC and Vector instructions are non-privileged, neither special VM/LPAR configuration nor root are required.
+
+The CI uses a self-hosted builder, provided by marist university. There is no official IBM Z GitHub Actions runner, so we build one inspired by anup-kodlekere/gaplib. Future updates to actions-runner might need an updated patch. The .net version number patch has been separated into a separate file to avoid a need for constantly changing the patch.
+
+### Setup
+
+1. request an account at https://linuxone.cloud.marist.edu/#/login and create a VM
+2. install podman:
+
+```
+sudo apt update
+sudo apt upgrade
+sudo apt install podman
+```
+
+3. request an action runner authentication token via the github project website: 
+```
+Settings->Actions->Runners->New self-hosted runner
+```
+4. checkout zlib and setup the token in the actions_runner_conf.sh file:
+```
+git clone https://github.com/fneddy/zlib.git -b s390x_native_ci
+```
+```
+cd zlib/contrib/s390x/self-hosted-builder/
+nano actions_runner_conf.sh
+
+# add the created token to the conf:
+# REPO="madler/zlib"
+# TOKEN="AAGXXXXXXXXXXXXXXXXXXXXXXXXXX"
+# LABEL="S390X"
+```
+5. build the action runner container:
+```
+podman build --squash -f actions_runner_ubuntu.Dockerfile --tag zlib/actions_runner .
+```
+6. start the actions runner via either:
+
+- directly running it from cli
+```
+podman run --rm -it zlib/actions_runner
+```
+- let systemd quadlet hooks start it automatically
+```
+mkdir -p $HOME/.config/containers/systemd/
+cp actions_runner.container $HOME/.config/containers/systemd/
+systemctl --user daemon-reload
+systemctl --user start zlib_actions_runner
+sudo -E loginctl enable-linger $USER
+```

--- a/contrib/s390x/self-hosted-builder/actions_runner.container
+++ b/contrib/s390x/self-hosted-builder/actions_runner.container
@@ -1,0 +1,9 @@
+[Unit]
+Description=GitHub Actions Worker for zlib
+
+[Container]
+Image=zlib/actions_runner
+
+[Install]
+WantedBy=multi-user.target default.target
+

--- a/contrib/s390x/self-hosted-builder/actions_runner.sh
+++ b/contrib/s390x/self-hosted-builder/actions_runner.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+#
+# action runner startup script.
+#
+# Expects the following environment variables:
+#
+# - REPO=<owner>
+# - TOKEN=<***>
+# - LABEL=<LABELS for this runner>
+#
+
+set -e -u
+source /etc/actions_runner_conf
+
+# Validate required environment variables
+if [ -z "${REPO:-}" ] || [ -z "${TOKEN:-}" ] || [ -z "${LABEL:-}" ]; then
+    echo "Error: REPO and/or TOKEN and/or LABEL environment variables not found"
+    exit 1
+fi
+
+./config.sh \
+    --unattended \
+    --url "https://github.com/$REPO" \
+    --token "$TOKEN" \
+    --disableupdate \
+    --name "${LABEL}_actions_runner" \
+    --replace \
+    --labels "$LABEL"
+
+# Run the actions-runner
+./run.sh

--- a/contrib/s390x/self-hosted-builder/actions_runner_conf.sh
+++ b/contrib/s390x/self-hosted-builder/actions_runner_conf.sh
@@ -1,0 +1,3 @@
+REPO="madler/zlib"
+TOKEN="AAG..."
+LABEL="S390X"

--- a/contrib/s390x/self-hosted-builder/actions_runner_ubuntu.Dockerfile
+++ b/contrib/s390x/self-hosted-builder/actions_runner_ubuntu.Dockerfile
@@ -1,0 +1,52 @@
+FROM    ubuntu:24.10
+
+ARG     RUNNER_PATCH="https://github.com/anup-kodlekere/gaplib/raw/1a5e012e8af1ff96f482f493ba1c27eb115930af/patches/runner-main-sdk8-s390x.patch"
+ARG     RUNNER_REPO="https://github.com/actions/runner"
+ARG     ACTIONS_RUNNER_SCRIPT="actions_runner.sh"
+ARG     ACTIONS_RUNNER_CONFIG="actions_runner_conf.sh"
+
+ENV     DEBIAN_FRONTEND=noninteractive
+
+# install dependencies
+RUN     apt-get -qq update -y && \
+        apt-get -qq -y install wget git sudo curl dotnet-sdk-8.0 && \
+        apt-get autoclean 
+
+# load actions runner
+RUN     cd /tmp && \
+        git clone -q ${RUNNER_REPO} && \
+        cd runner && \
+        git checkout main -b build && \
+        wget ${RUNNER_PATCH} -O runner.patch && \
+        git apply runner.patch && \
+        sed -i'' -e /version/s/8......\"$/$8.0.100\"/ src/global.json
+
+# build actions runner
+RUN     cd /tmp/runner/src && \
+        ./dev.sh layout && \
+        ./dev.sh package && \
+        rm -rf /root/.dotnet /root/.nuget
+
+# setup actions runner env
+RUN     useradd -c "Actions Runner" -m actions_runner && \
+        usermod -L actions_runner
+
+RUN     tar -xf /tmp/runner/_package/*.tar.gz -C /home/actions_runner && \
+        chown -R actions_runner:actions_runner /home/actions_runner
+
+# cleanup
+RUN     rm -rf /tmp/runner
+
+# install build utils for the CI
+RUN     apt-get -qq update -y && \
+        apt-get -qq -y install build-essential cmake ninja-build clang g++ \
+        python3 flex bison jq pkg-config rsync && \
+        apt-get autoclean 
+
+# setup container config
+USER    actions_runner
+EXPOSE  443
+COPY    --chmod=0555 ${ACTIONS_RUNNER_SCRIPT} /usr/bin/actions_runner
+COPY    --chmod=0444 ${ACTIONS_RUNNER_CONFIG} /etc/actions_runner_conf
+WORKDIR /home/actions_runner
+ENTRYPOINT     ["/usr/bin/actions_runner"]


### PR DESCRIPTION
# Background

As mentioned in #1050 `Qemu` does not implement the hardware acceleration instructions for `S390X`. Therefor a Qemu based CI will **never** actually test the code but fallback and use the software implementation. For this reason its **highly desirable** to run the zlib CI on a _real_ S390X IBM System Z worker. 

#  Setup

This PR adds CI jobs for native S390X workers.
GitHub has not yet support for this architecture. Therefore its necessary to add self-hosted workers.
Marist University offers free workers for open source projects with their [LinuxONE Community Cloud](https://linuxone.cloud.marist.edu/).

### Job Control
The self-hosted worker setup does not allow forks to run their CI jobs on the worker. Therefor it is necessary to deactivate this new jobs for forks. 
Currently **its not possible** to deactivate or skip a GitHub Action Job. Therefor I added an `enabled` flag to the `cmake` and `configure` job matrix. Together with a repository check (`${{ github.repository == 'madler/zlib' && 'true' || 'false' }}`) the new CI jobs can be `disabled` for forks. By filtering on this flag in the job steps forks could be set to `always succeed` or `always fail` .

### S390X worker
GitHub does not officially support S390X as a worker. With [gaplib](https://github.com/anup-kodlekere/gaplib) its possible to connect an S390X instance as a self-hosted worker. 
This raises some questions: Should we add the gaplib-scripts to the zlib src ([zlib-ng did that](https://github.com/zlib-ng/zlib-ng/tree/develop/arch/s390/self-hosted-builder)). Who will maintain the `self-hosted` worker at the LinuxONE Community Cloud? I've already setup an account for testing and am willing to take this responsibility. But if its decided that it should be maintained by an official zlib maintainer I am happy to assist with the setup. If I shall maintain the worker, I need a communication channel with a zlib maintainer to exchange the github tokens.

# Open Questions
- [X] should the `native S390X` CI run on forks be always failing or always success ? -> @fneddy votes for always success
- [x] should gaplib scripts  be added to the `contrib` folder? -> ~@fneddy  no~ / @iii-i yes 
- [x] who will maintain the LinuxOne Instance -> @fneddy 
- [x] how will the zlib github token find its way to the LinuxOne instance -> email to @fneddy encrypted via smime or pgp