### PR TITLE
Replace genrule with copy_files macro for copying headers

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -36,6 +36,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@rules_license//rules:license.bzl", "license")
+load(":copy_files.bzl", "copy_files")
 
 package(
     default_applicable_licenses = [":license"],
@@ -70,15 +71,10 @@ _ZLIB_PREFIXED_HEADERS = ["zlib/include/" + hdr for hdr in _ZLIB_HEADERS]
 # In order to limit the damage from the `includes` propagation
 # via `:zlib`, copy the public headers to a subdirectory and
 # expose those.
-genrule(
+copy_files(
     name = "copy_public_headers",
     srcs = _ZLIB_HEADERS,
-    outs = _ZLIB_PREFIXED_HEADERS,
-    cmd_bash = "cp $(SRCS) $(@D)/zlib/include/",
-    cmd_bat = " && ".join(
-        ["@copy /Y \"$(location %s)\" \"$(@D)\\zlib\\include\\\"  >NUL" %
-         s for s in _ZLIB_HEADERS],
-    ),
+    subdirectory = "zlib/include",
 )
 
 config_setting(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,3 +7,4 @@ module(
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_cc", version = "0.0.16")
 bazel_dep(name = "rules_license", version = "1.0.0")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/copy_files.bzl
+++ b/copy_files.bzl
@@ -1,0 +1,31 @@
+"""Contains the copy_files macro for moving files."""
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
+
+def copy_files(name, srcs, subdirectory):
+    """Copy files to the subdirectory.
+
+    Every file is copied in a separate target using the target label
+    "$name_$src.basename". A filegroup target "$name" contains all the
+    copied files.
+
+    Args:
+        name: Name of filegroup containing all files.
+        srcs: The relative filepaths of the files to copy.
+        subdirectory: The subdirectory path to copy the files into.
+    """
+    outs = []
+    for src in srcs:
+        basename = src.split('/')[-1]
+        src_label = name + "_" + basename
+        copy_file(
+            name = src_label,
+            src = src,
+            out = subdirectory + '/' + src,
+        )
+        outs.append(src_label)
+    native.filegroup(
+        name = name,
+        srcs = outs,
+    )
+
+


### PR DESCRIPTION
The existing genrule for copying files does not work for Windows when using Bazel 7.X and using RBE. See https://github.com/bazelbuild/bazel/issues/11636

The copy_files macro uses skylib's copy_file rule to do the actual copying and does not run into the issue mentioned above.