### PR TITLE
Add License variable to pkg-config file

### DIFF
--- a/contrib/minizip/minizip.pc.in
+++ b/contrib/minizip/minizip.pc.in
@@ -7,6 +7,7 @@ Name: minizip
 Description: Minizip zip file manipulation library
 Requires:
 Version: @PACKAGE_VERSION@
+License: Zlib
 Libs: -L${libdir} -lminizip
 Libs.private: -lz
 Cflags: -I${includedir}

--- a/zlib.pc.cmakein
+++ b/zlib.pc.cmakein
@@ -7,6 +7,7 @@ includedir=${exec_prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 Name: zlib
 Description: zlib compression library
 Version: @zlib_VERSION@
+License: Zlib
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz

--- a/zlib.pc.in
+++ b/zlib.pc.in
@@ -7,6 +7,7 @@ includedir=@includedir@
 Name: zlib
 Description: zlib compression library
 Version: @VERSION@
+License: Zlib
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz


### PR DESCRIPTION
The pkg-config file has License variable that that sets the software license.
This sets 'Zlib' as defined in SPDX to License.

Ref: https://github.com/pkgconf/pkgconf/blob/master/man/pc.5#L116