### PR TITLE
fix: prevent potential double-free in makedir() by nullifying freed p…

### DIFF
--- a/contrib/untgz/untgz.c
+++ b/contrib/untgz/untgz.c
@@ -330,10 +330,11 @@ int makedir (char *newdir)
   char *p;
   int  len = strlen(buffer);
 
-  if (len <= 0) {
+if (len <= 0) {
     free(buffer);
+    buffer = NULL; // Prevent use-after-free or double-free
     return 0;
-  }
+}
   if (buffer[len-1] == '/') {
     buffer[len-1] = '\0';
   }


### PR DESCRIPTION
This patch prevents a potential double-free vulnerability in makedir() by nullifying the buffer pointer after freeing it when len <= 0. Double-free bugs can lead to memory corruption or crashes.