### PR TITLE
Really use clang in miongw-clang64

### DIFF
--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -29,8 +29,18 @@ jobs:
           toolchain:p
           cmake:p
     - name: Configure
+      if: matrix.sys != 'clang64'
       run: |
         cmake -G"Unix Makefiles" \
+          -S . \
+          -B build \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DMINIZIP_ENABLE_BZIP2=ON
+    - name: Configure clang64
+      if: matrix.sys == 'clang64'
+      run: |
+        CC=clang cmake -G"Unix Makefiles" \
           -S . \
           -B build \
           -DCMAKE_VERBOSE_MAKEFILE=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,6 @@ unset(CMAKE_COMPILE_FLAGS)
 set(ZLIB_PC ${zlib_BINARY_DIR}/zlib.pc)
 configure_file(${zlib_SOURCE_DIR}/zlib.pc.cmakein ${ZLIB_PC} @ONLY)
 configure_file(${zlib_BINARY_DIR}/zconf.h.cmakein ${zlib_BINARY_DIR}/zconf.h)
-include_directories(${zlib_BINARY_DIR} ${zlib_SOURCE_DIR})
 
 # ============================================================================
 # zlib
@@ -172,7 +171,8 @@ if(ZLIB_BUILD_SHARED)
                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     target_compile_definitions(
         zlib
-        PRIVATE $<$<BOOL:NOT:${HAVE_FSEEKO}>:NO_FSEEKO>
+        PRIVATE ZLIB_BUILD
+                $<$<BOOL:NOT:${HAVE_FSEEKO}>:NO_FSEEKO>
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>
                 $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_DEPRECATE>
                 $<$<BOOL:${MSVC}>:_CRT_NONSTDC_NO_DEPRECATE>
@@ -214,7 +214,8 @@ if(ZLIB_BUILD_STATIC)
                $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     target_compile_definitions(
         zlibstatic
-        PRIVATE $<$<BOOL:NOT:${HAVE_FSEEKO}>:NO_FSEEKO>
+        PRIVATE ZLIB_BUILD
+                $<$<BOOL:NOT:${HAVE_FSEEKO}>:NO_FSEEKO>
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>
                 $<$<BOOL:${MSVC}>:_CRT_SECURE_NO_DEPRECATE>
                 $<$<BOOL:${MSVC}>:_CRT_NONSTDC_NO_DEPRECATE>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,7 +191,8 @@ if(ZLIB_BUILD_SHARED)
                    OUTPUT_NAME z)
     if(UNIX
        AND NOT APPLE
-       AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX))
+       AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX)
+       AND NOT (${CMAKE_C_COMPILER_ID} STREQUAL "Clang"))
         # On unix-like platforms the library is almost always called libz
         set_target_properties(
             zlib
@@ -200,7 +201,8 @@ if(ZLIB_BUILD_SHARED)
     endif(
         UNIX
         AND NOT APPLE
-        AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX))
+        AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX)
+        AND NOT (${CMAKE_C_COMPILER_ID} STREQUAL "Clang"))
 endif(ZLIB_BUILD_SHARED)
 
 if(ZLIB_BUILD_STATIC)

--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -89,6 +89,9 @@ check_c_source_compiles(
 
 unset(CMAKE_REQUIRED_FLAGS)
 
+include(CheckSymbolExists)
+check_symbol_exists(_WIN32 stdlib.h IS_WIN)
+
 if(NOT TARGET ZLIB::ZLIB)
     find_package(ZLIB REQUIRED CONFIG)
 endif(NOT TARGET ZLIB::ZLIB)
@@ -97,19 +100,19 @@ set(LIBMINIZIP_SRCS ioapi.c mztools.c unzip.c zip.c)
 
 set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h mztools.h unzip.h zip.h)
 
-set(MINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> minizip.c zip.c)
+set(MINIZIP_SRCS ioapi.c $<$<BOOL:${IS_WIN}>:iowin32.c> minizip.c zip.c)
 
-set(MINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${WIN32}>:iowin32.h> skipset.h
+set(MINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${IS_WIN}>:iowin32.h> skipset.h
                  zip.h)
 
-set(MINIUNZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> miniunz.c unzip.c
+set(MINIUNZIP_SRCS ioapi.c $<$<BOOL:${IS_WIN}>:iowin32.c> miniunz.c unzip.c
                    zip.c)
 
 set(MINIUNZIP_HDRS
     crypt.h
     ints.h
     ioapi.h
-    $<$<BOOL:${WIN32}>:iowin32.h>
+    $<$<BOOL:${IS_WIN}>:iowin32.h>
     skipset.h
     unzip.h
     zip.h)

--- a/contrib/minizip/test/add_subdirectory_exclude_test.cmake.in
+++ b/contrib/minizip/test/add_subdirectory_exclude_test.cmake.in
@@ -10,12 +10,15 @@ option(MINIZIP_BUILD_SHARED "" @MINIZIP_BUILD_SHARED@)
 option(MINIZIP_BUILD_STATIC "" @MINIZIP_BUILD_STATIC@)
 option(MINIZIP_ENABLE_BZIP2 "" @MINIZIP_ENABLE_BZIP2@)
 
+include(CheckSymbolExists)
+check_symbol_exists(_WIN32 stdlib.h IS_WIN)
+
 add_subdirectory(@minizip_SOURCE_DIR@ ${CMAKE_CURRENT_BINARY_DIR}/minizip
                  EXCLUDE_FROM_ALL)
 
 set(MINIZIP_SRCS
     @minizip_SOURCE_DIR@/ioapi.c
-    $<$<BOOL:${WIN32}>:@minizip_SOURCE_DIR@/iowin32.c>
+    $<$<BOOL:${IS_WIN}>:@minizip_SOURCE_DIR@/iowin32.c>
     @minizip_SOURCE_DIR@/minizip.c @minizip_SOURCE_DIR@/zip.c)
 
 if(MINIZIP_BUILD_SHARED)

--- a/contrib/minizip/test/add_subdirectory_test.cmake.in
+++ b/contrib/minizip/test/add_subdirectory_test.cmake.in
@@ -12,9 +12,12 @@ option(MINIZIP_ENABLE_BZIP2 "" @MINIZIP_ENABLE_BZIP2@)
 
 add_subdirectory(@minizip_SOURCE_DIR@ ${CMAKE_CURRENT_BINARY_DIR}/minizip)
 
+include(CheckSymbolExists)
+check_symbol_exists(_WIN32 stdlib.h IS_WIN)
+
 set(MINIZIP_SRCS
     @minizip_SOURCE_DIR@/ioapi.c
-    $<$<BOOL:${WIN32}>:@minizip_SOURCE_DIR@/iowin32.c>
+    $<$<BOOL:${IS_WIN}>:@minizip_SOURCE_DIR@/iowin32.c>
     @minizip_SOURCE_DIR@/minizip.c @minizip_SOURCE_DIR@/zip.c)
 
 if(MINIZIP_BUILD_SHARED)

--- a/contrib/minizip/test/find_package_test.cmake.in
+++ b/contrib/minizip/test/find_package_test.cmake.in
@@ -9,9 +9,12 @@ option(MINIZIP_BUILD_SHARED "" @MINIZIP_BUILD_SHARED@)
 option(MINIZIP_BUILD_STATIC "" @MINIZIP_BUILD_STATIC@)
 find_package(minizip ${minizip_VERSION} CONFIG REQUIRED)
 
+include(CheckSymbolExists)
+check_symbol_exists(_WIN32 stdlib.h IS_WIN)
+
 set(MINIZIP_SRCS
     @minizip_SOURCE_DIR@/ioapi.c
-    $<$<BOOL:${WIN32}>:@minizip_SOURCE_DIR@/iowin32.c>
+    $<$<BOOL:${IS_WIN}>:@minizip_SOURCE_DIR@/iowin32.c>
     @minizip_SOURCE_DIR@/minizip.c @minizip_SOURCE_DIR@/zip.c)
 
 if(MINIZIP_BUILD_SHARED)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ endfunction()
 if(ZLIB_BUILD_SHARED)
     add_executable(zlib_example example.c)
     target_link_libraries(zlib_example ZLIB::ZLIB)
+    target_compile_definitions(zlib_example PRIVATE ZLIB_BUILD)
     add_test(NAME zlib_example COMMAND zlib_example)
 
     add_executable(minigzip minigzip.c)
@@ -38,7 +39,7 @@ if(ZLIB_BUILD_SHARED)
         add_executable(zlib_example64 example.c)
         target_compile_definitions(
             zlib_example64
-            PRIVATE LARGEFILE64_SOURCE=1
+            PRIVATE ZLIB_BUILD
                     $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
         target_link_libraries(zlib_example64 ZLIB::ZLIB)
         add_test(NAME zlib_example64 COMMAND zlib_example64)
@@ -61,7 +62,8 @@ if(ZLIB_BUILD_STATIC)
     target_link_libraries(zlib_static_example ZLIB::ZLIBSTATIC)
     target_compile_definitions(
         zlib_static_example
-        PRIVATE $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
+        PRIVATE ZLIB_BUILD
+                $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
     add_test(NAME zlib_static_example COMMAND zlib_static_example)
 
     add_executable(static_minigzip minigzip.c)
@@ -116,7 +118,7 @@ if(ZLIB_BUILD_STATIC)
         add_executable(zlib_static_example64 example.c)
         target_compile_definitions(
             zlib_static_example64
-            PRIVATE LARGEFILE64_SOURCE=1
+            PRIVATE ZLIB_BUILD
                     $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
         target_link_libraries(zlib_static_example64 ZLIB::ZLIBSTATIC)
         add_test(NAME zlib_static_example64 COMMAND zlib_static_example64)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -72,7 +72,7 @@ if(ZLIB_BUILD_STATIC)
     if(${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL
                                                 "Clang")
         set(CFLAGS_OLD ${CMAKE_C_FLAGS})
-        set({CMAKE_C_FLAGS
+        set(CMAKE_C_FLAGS
             ""
             CACHE STRING "" FORCE)
 
@@ -108,7 +108,7 @@ if(ZLIB_BUILD_STATIC)
                 ${INFCOVER_DIR}/infcover.c.gcda)
         set_tests_properties(zlib-coverage-summary PROPERTIES DEPENDS
                                                               zlib-coverage)
-        set({CMAKE_C_FLAGS
+        set(CMAKE_C_FLAGS
             ${CFLAGS_OLD}
             CACHE STRING "" FORCE)
     endif(${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,13 +89,15 @@ if(ZLIB_BUILD_STATIC)
             endforeach(ver RANGE 11 99)
 
             find_program(GCOV_EXECUTABLE NAMES ${llvm_names})
+
             set(llvm_option "gcov")
+            set(compile_opts -rtlib=compiler_rt)
         endif(${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
 
         add_executable(infcover infcover.c)
         target_link_libraries(infcover ZLIB::ZLIBSTATIC)
-        target_compile_options(infcover PRIVATE -coverage)
-        target_link_options(infcover PRIVATE -coverage)
+        target_compile_options(infcover PRIVATE --coverage ${compile_opts})
+        target_link_options(infcover PRIVATE --coverage)
         target_compile_definitions(
             infcover PRIVATE $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
         add_test(NAME zlib-coverage COMMAND infcover)

--- a/zlib.h
+++ b/zlib.h
@@ -31,7 +31,11 @@
 #ifndef ZLIB_H
 #define ZLIB_H
 
-#include <zconf.h>
+#ifdef ZLIB_BUILD
+#  include <zconf.h>
+#else
+# include "zconf.h"
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Hi,

first I was sure the typo-fix was already merged, but I don't seem to get any newer commit to sync to.

It seems that there is a mingw flavour that's fully built with clang toolchain, but when I set CC=clang, some things broken. These problems are fixed now. Don't ask me why clang is not set as default on a system completely built with clang.