### PR TITLE
CI: Enable CI for CMake Builds on Windows on ARM

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,7 +58,7 @@ jobs:
             cmake-args: -G Ninja -DMINIZIP_ENABLE_BZIP2=OFF
             pkgtgt: package
 
-          - name: Windows MSVC Win-ARM64
+          - name: Windows MSVC ARM64
             os: windows-11-arm
             compiler: cl
             cflags: /W3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -58,6 +58,13 @@ jobs:
             cmake-args: -G Ninja -DMINIZIP_ENABLE_BZIP2=OFF
             pkgtgt: package
 
+          - name: Windows MSVC Win-ARM64
+            os: windows-11-arm
+            compiler: cl
+            cflags: /W3
+            cmake-args: -A ARM64 -DMINIZIP_ENABLE_BZIP2=OFF
+            pkgtgt: PACKAGE
+
           - name: macOS Clang
             os: macos-latest
             compiler: clang


### PR DESCRIPTION
The PR adds support for testing and building zlib library in CI for Windows on ARM 