### PR TITLE
Improve robustness of gz_open by adding a null check for the 'mode' parameter

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -94,7 +94,7 @@ local gzFile gz_open(const void *path, int fd, const char *mode) {
 #endif
 
     /* check input */
-    if (path == NULL)
+    if (path == NULL || mode == NULL)
         return NULL;
 
     /* allocate gzFile structure to return */


### PR DESCRIPTION
Thank you for your excellent work on this library.

This PR proposes a change to improve the robustness of the `gz_open` function by adding a `NULL` check for the mode parameter.

This ensures its argument validation is consistent with the existing check for the `path` parameter. More importantly, it prevents a potential segmentation fault if the function is called with a NULL mode, making it safer and more predictable for users.

I hope you find this a welcome improvement. Thank you for your time and for considering this contribution.