### PR TITLE
Improve: Add Defensive Null Checks to uncompress2

### DIFF
--- a/uncompr.c
+++ b/uncompr.c
@@ -32,6 +32,14 @@ int ZEXPORT uncompress2(Bytef *dest, uLongf *destLen, const Bytef *source,
     uLong len, left;
     Byte buf[1];    /* for detection of incomplete stream when *destLen == 0 */
 
+    if (source == NULL || sourceLen == NULL || destLen == NULL) {
+        return Z_STREAM_ERROR;
+    }
+
+    if (*destLen > 0 && dest == NULL) {
+        return Z_STREAM_ERROR;
+    }
+
     len = *sourceLen;
     if (*destLen) {
         left = *destLen;


### PR DESCRIPTION
Hello team,

This PR improves the robustness of the uncompress2 function by adding defensive parameter validation.

Currently, passing NULL for essential pointers like sourceLen or destLen will cause a segmentation fault. This change prevents this crash by adding checks at the beginning of the function.

If any parameter is invalid, the function now returns Z_STREAM_ERROR, providing the caller with a clear and actionable error instead of a crash. This behavior is consistent with the library's conventions for handling invalid arguments.

I believe this makes the function safer and easier to debug for developers. Happy to address any feedback.

Thank you for your time and consideration.