### PR TITLE
Provide ZLIB::ZLIB as a CMake alias when shared libraries are disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,9 @@ if(ZLIB_BUILD_STATIC)
     add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS}
                                   ${ZLIB_PRIVATE_HDRS})
     add_library(ZLIB::ZLIBSTATIC ALIAS zlibstatic)
+    if(NOT ZLIB_BUILD_SHARED)
+        add_library(ZLIB::ZLIB ALIAS zlibstatic)
+    endif()
     target_include_directories(
         zlibstatic
         PUBLIC $<BUILD_INTERFACE:${zlib_BINARY_DIR}>

--- a/zlibConfig.cmake.in
+++ b/zlibConfig.cmake.in
@@ -24,3 +24,7 @@ else(ZLIB_FIND_COMPONENTS)
         include("${CMAKE_CURRENT_LIST_DIR}/ZLIB-${_component_config}.cmake")
     endforeach(_component_config IN LISTS _ZLIB_supported_components)
 endif(ZLIB_FIND_COMPONENTS)
+
+if(@ZLIB_BUILD_STATIC@ AND NOT @ZLIB_BUILD_SHARED@)
+    add_library(ZLIB::ZLIB ALIAS ZLIB::ZLIBSTATIC)
+endif(@ZLIB_BUILD_STATIC@ AND NOT @ZLIB_BUILD_SHARED@)


### PR DESCRIPTION
This matches the behaviour of `FindZLIB` from standard CMake installations.