### PR TITLE
Updates vstudio gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,10 @@
 .vs
 *.user
 *.nupkg
-contrib/vstudio/vc143/x86
-contrib/vstudio/vc143/x64
-contrib/vstudio/vc143/arm
-contrib/vstudio/vc143/arm64
+contrib/vstudio/vc*/x86
+contrib/vstudio/vc*/x64
+contrib/vstudio/vc*/arm
+contrib/vstudio/vc*/arm64
 contrib/nuget/bin
 contrib/nuget/obj
 *.included


### PR DESCRIPTION
The gitignore had outdated paths

https://github.com/madler/zlib/tree/develop/contrib/vstudio