### PR TITLE
[OS400] Fixed BNDSRC copy to QSYS.LIB

### DIFF
--- a/os400/make.sh
+++ b/os400/make.sh
@@ -311,7 +311,7 @@ fi
 
 DEST="${LIBIFSNAME}/TOOLS.FILE/BNDSRC.MBR"
 
-if action_needed "${SCRIPTDIR}/bndsrc" "${DEST}"
+if action_needed "${DEST}" "${SCRIPTDIR}/bndsrc"
 then    CMD="CPY OBJ('${SCRIPTDIR}/bndsrc') TOOBJ('${DEST}')"
         CMD="${CMD} TOCCSID(${TGTCCSID}) DTAFMT(*TEXT) REPLACE(*YES)"
         system "${CMD}"


### PR DESCRIPTION
Hi ! 

The os400/make.sh build script didn't copy bndsrc to my library, hence the service program wasn't created.
I had this config :
```sh
TARGETLIB='ZLIB'                # Target OS/400 program library
STATBNDDIR='ZLIB_A'             # Static binding directory.
DYNBNDDIR='ZLIB'                # Dynamic binding directory.
SRVPGM="ZLIB"                   # Service program.
OUTPUT='ZLIB'                  # Compilation output option.
```

I thus got messages :
1. CPF5D05 : Service program not created
2. CPF2105 : Object ZLIB in ZLIB type *SRVPGM not found
3. CPF2130 : 0 object(s) duplicated, 1 object(s) not duplicated
4. CPC5D02 : The ZLIB link directory wad created in the ZLIB directory
5. CPC5D05 : 1 entries added, 0 entries not added to the ZLIB link directory in the ZLIB library.

After my change, it works as intended and builds the service program and the BNDDIR.

Anyways, thanks for supporting OS400 !