### PR TITLE
[OS400] Fixed service program path, specified library instead of *LIBL

### DIFF
--- a/os400/make.sh
+++ b/os400/make.sh
@@ -361,6 +361,6 @@ then    rm -rf "${LIBIFSNAME}/${DYNBNDDIR}.BNDDIR"
         CMD="${CMD} TEXT('ZLIB dynamic binding directory')"
         system "${CMD}"
         CMD="ADDBNDDIRE BNDDIR(${TARGETLIB}/${DYNBNDDIR})"
-        CMD="${CMD} OBJ((*LIBL/${SRVPGM} *SRVPGM))"
+        CMD="${CMD} OBJ((${TARGETLIB}/${SRVPGM} *SRVPGM))"
         system "${CMD}"
 fi


### PR DESCRIPTION
Hi !

https://github.com/madler/zlib/blob/5a82f71ed1dfc0bec044d9702463dbdf84ea3b71/os400/make.sh#L15
In os400/make.sh, we can choose in which library the final service program is outputted, and the library is even created if it doesn't exist :
https://github.com/madler/zlib/blob/5a82f71ed1dfc0bec044d9702463dbdf84ea3b71/os400/make.sh#L164-L169
We can see the service program being created there in `${TARGETLIB}` :
https://github.com/madler/zlib/blob/5a82f71ed1dfc0bec044d9702463dbdf84ea3b71/os400/make.sh#L329-L337

But at the end, when adding the service program to the BNDDIR, it's passed as `*LIBL/${SRVPGM}` and not as `${TARGETLIB}/${SRVPGM}`.
https://github.com/madler/zlib/blob/5a82f71ed1dfc0bec044d9702463dbdf84ea3b71/os400/make.sh#L363-L365

Seems like an issue to me, as the newly created library isn't added to *LIBL, so it seems wrong to search the service program in *LIBL.