### PR TITLE
Fix file descriptor and file leak in minigzip

### DIFF
--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -438,6 +438,7 @@ static void file_compress(char *file, char *mode) {
     }
     out = gzopen(outfile, mode);
     if (out == NULL) {
+        fclose(in);
         fprintf(stderr, "%s: can't gzopen %s\n", prog, outfile);
         exit(1);
     }
@@ -480,6 +481,7 @@ static void file_uncompress(char *file) {
     }
     out = fopen(outfile, "wb");
     if (out == NULL) {
+        gzclose(in);
         perror(file);
         exit(1);
     }


### PR DESCRIPTION
In test/minigzip.c I found a potential file descriptor and memory leak.
When the first resource allocation is successful, and the second resource allocation fails, this will happen.
This pr means to fix these bugs.