### PR TITLE
Change 1997 DrDobb's article broken link, to Internet Archive.

### DIFF
--- a/FAQ
+++ b/FAQ
@@ -19,7 +19,7 @@ The latest zlib FAQ is at http://zlib.net/zlib_faq.html
  3. Where can I get a Visual Basic interface to zlib?
 
     See
-        * https://marknelson.us/posts/1997/01/01/zlib-engine.html
+        * https://web.archive.org/web/20241208081019/https://marknelson.us/posts/1997/01/01/zlib-engine.html
         * win32/DLL_FAQ.txt in the zlib distribution
 
  4. compress() returns Z_BUF_ERROR.

--- a/README
+++ b/README
@@ -29,7 +29,7 @@ PLEASE read the zlib FAQ http://zlib.net/zlib_faq.html before asking for help.
 
 Mark Nelson <markn@ieee.org> wrote an article about zlib for the Jan.  1997
 issue of Dr.  Dobb's Journal; a copy of the article is available at
-https://marknelson.us/posts/1997/01/01/zlib-engine.html .
+https://web.archive.org/web/20241208081019/https://marknelson.us/posts/1997/01/01/zlib-engine.html .
 
 The changes made in version 1.3.1.1 are documented in the file ChangeLog.
 

--- a/zlib.3
+++ b/zlib.3
@@ -86,7 +86,7 @@ Mark Nelson wrote an article about
 for the Jan. 1997 issue of  Dr. Dobb's Journal;
 a copy of the article is available at:
 .IP
-https://marknelson.us/posts/1997/01/01/zlib-engine.html
+https://web.archive.org/web/20241208081019/https://marknelson.us/posts/1997/01/01/zlib-engine.html
 .SH "REPORTING PROBLEMS"
 Before reporting a problem,
 please check the


### PR DESCRIPTION
The new link goes to the last Internet Archive snapshot from 2024-12-08. The next ones, from 2024-12-27 to 2025-04-07 contain a 404 Not Found page.
From 2025-04-26 on they contain/redirect to a domain parking page.

The URL gets well beyond 80 columns, I would suggest hosting it under `zlib.net` to get a shorter URL.

Fixes #1105.