### PR TITLE
CMake: keep cpack package name same with `find_package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(
 # ============================================================================
 # CPack
 # ============================================================================
+set(CPACK_PACKAGE_NAME "ZLIB")
 set(CPACK_PACKAGE_VENDOR "zlib-Project")
 set(CPACK_PACKAGE_DESCRIPTION_FILE ${zlib_SOURCE_DIR}/README)
 set(CPACK_RESOURCE_FILE_LICENSE ${zlib_SOURCE_DIR}/LICENSE)


### PR DESCRIPTION
keep same with [`FindZLIB`](https://cmake.org/cmake/help/latest/module/FindZLIB.html)

P.S. cpack support for this library is not released yet, so I think it's safe to fix it now.