### PR TITLE
CMake: Dynamic libraries can only be searched if they have been gener…

### DIFF
--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -89,9 +89,11 @@ check_c_source_compiles(
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-if(NOT TARGET ZLIB::ZLIB)
-    find_package(ZLIB REQUIRED CONFIG)
-endif(NOT TARGET ZLIB::ZLIB)
+if(ZLIB_BUILD_SHARED)
+    if(NOT TARGET ZLIB::ZLIB)
+        find_package(ZLIB REQUIRED CONFIG)
+    endif(NOT TARGET ZLIB::ZLIB)
+endif()
 
 set(LIBMINIZIP_SRCS ioapi.c mztools.c unzip.c zip.c)
 

--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -89,7 +89,7 @@ check_c_source_compiles(
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-if(ZLIB_BUILD_SHARED)
+if(MINIZIP_BUILD_SHARED)
     if(NOT TARGET ZLIB::ZLIB)
         find_package(ZLIB REQUIRED CONFIG)
     endif(NOT TARGET ZLIB::ZLIB)


### PR DESCRIPTION
#1086 

Dynamic libraries can only be searched if they have been generated.