### PR TITLE
Actions fixes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -79,7 +79,7 @@ jobs:
     - name: Install packages (Windows)
       if: runner.os == 'Windows'
       run: |
-        choco install --no-progress ninja
+        choco install --no-progress nsis
 
     - name: Install packages (Linux)
       if: runner.os == 'Linux'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -65,9 +65,23 @@ jobs:
             pkgtgt: package
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
 
-          - name: macOS GCC
+          - name: macOS GCC 13
             os: macos-latest
-            compiler: gcc-12
+            compiler: gcc-13
+            cflags: -Wall -Wextra
+            pkgtgt: package
+            cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
+
+          - name: macOS GCC 14
+            os: macos-latest
+            compiler: gcc-14
+            cflags: -Wall -Wextra
+            pkgtgt: package
+            cmake-args: -DMINIZIP_ENABLE_BZIP2=ON
+
+          - name: macOS GCC 15
+            os: macos-latest
+            compiler: gcc-15
             cflags: -Wall -Wextra
             pkgtgt: package
             cmake-args: -DMINIZIP_ENABLE_BZIP2=ON

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -83,9 +83,19 @@ jobs:
             cflags: -static
             ldflags: -static
 
-          - name: macOS GCC
+          - name: macOS GCC 13
             os: macos-latest
-            compiler: gcc-12
+            compiler: gcc-13
+            configure-args: --warn
+
+          - name: macOS GCC 14
+            os: macos-latest
+            compiler: gcc-14
+            configure-args: --warn
+
+          - name: macOS GCC 15
+            os: macos-latest
+            compiler: gcc-15
             configure-args: --warn
 
           - name: macOS Clang


### PR DESCRIPTION
While recreating my PRs in a clean way I've noticed that the recent updates to the actions runners broke some workflows.

- Windows doesn't have nsis installed by default
- Mac removed gcc-12 and now provides gcc-13, 14 and 15