### PR TITLE
Feature/c389033 custom gzip header

### DIFF
--- a/test/minigzip_meta.c
+++ b/test/minigzip_meta.c
@@ -1,0 +1,204 @@
+// test/minigzip_meta.c
+// 간단한 예제: gzip 헤더의 FEXTRA 영역에
+//  - AU(Author)
+//  - DT(Date)
+// 메타데이터를 넣어주는 프로그램
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "zlib.h"
+
+#define CHUNK 16384  /* 한 번에 읽고 쓰는 버퍼 크기 */
+
+/* -------------------------------------------------------
+ * Extra field (FEXTRA) 안에 사용자 메타데이터를 채우는 함수
+ *   형식:
+ *     [XLEN 2바이트]
+ *       [ID1][ID2][LEN(2)][데이터 ...]
+ *       [ID1][ID2][LEN(2)][데이터 ...] ...
+ * ----------------------------------------------------- */
+static size_t build_extra(unsigned char *buf, size_t max,
+                          const char *author, const char *date)
+{
+    unsigned char *p = buf;
+    uint16_t xlen = 0;
+
+    if (max < 2) {
+        return 0;
+    }
+
+    /* 나중에 XLEN을 채우기 위해 2바이트 비워두기 */
+    p += 2;
+
+    /* 1) AU 서브필드: 작성자 */
+    if (author && author[0] != '\0') {
+        size_t len = strlen(author);
+        if (max - (size_t)(p - buf) >= 4 + len) {
+            *p++ = 'A';
+            *p++ = 'U';
+            uint16_t L = (uint16_t)len;
+            *p++ = (unsigned char)(L & 0xff);      /* LEN low  */
+            *p++ = (unsigned char)((L >> 8) & 0xff); /* LEN high */
+            memcpy(p, author, len);
+            p += len;
+            xlen += (uint16_t)(4 + len);
+        }
+    }
+
+    /* 2) DT 서브필드: 날짜 */
+    if (date && date[0] != '\0') {
+        size_t len = strlen(date);
+        if (max - (size_t)(p - buf) >= 4 + len) {
+            *p++ = 'D';
+            *p++ = 'T';
+            uint16_t L = (uint16_t)len;
+            *p++ = (unsigned char)(L & 0xff);
+            *p++ = (unsigned char)((L >> 8) & 0xff);
+            memcpy(p, date, len);
+            p += len;
+            xlen += (uint16_t)(4 + len);
+        }
+    }
+
+    /* 맨 앞 2바이트에 XLEN 기록 (little endian) */
+    buf[0] = (unsigned char)(xlen & 0xff);
+    buf[1] = (unsigned char)((xlen >> 8) & 0xff);
+
+    return (size_t)(p - buf);  /* extra 전체 길이 (XLEN 포함) */
+}
+
+/* -------------------------------------------------------
+ * source 파일을 gzip 포맷으로 압축하면서,
+ * gzip 헤더에 meta(author, date)를 넣는 함수
+ * ----------------------------------------------------- */
+static int deflate_with_meta(FILE *source, FILE *dest,
+                             const char *author, const char *date)
+{
+    int ret;
+    unsigned have;
+    z_stream strm;
+    unsigned char in[CHUNK];
+    unsigned char out[CHUNK];
+
+    /* z_stream 초기화 */
+    memset(&strm, 0, sizeof(strm));
+    strm.zalloc = Z_NULL;
+    strm.zfree  = Z_NULL;
+    strm.opaque = Z_NULL;
+
+    /* 15 + 16  :  15비트 윈도우 + 16 -> gzip 포맷 사용 */
+    ret = deflateInit2(&strm,
+                       Z_DEFAULT_COMPRESSION,
+                       Z_DEFLATED,
+                       15 + 16,
+                       8,
+                       Z_DEFAULT_STRATEGY);
+    if (ret != Z_OK) {
+        return ret;
+    }
+
+    /* gzip 헤더 설정 */
+    gz_header header;
+    memset(&header, 0, sizeof(header));
+
+    header.os = 3;  /* 3 = UNIX (Windows면 0도 상관 없음) */
+
+    /* extra 버퍼 준비 후 메타데이터 채우기 */
+    unsigned char extra[256];
+    size_t extra_len = build_extra(extra, sizeof(extra), author, date);
+
+    if (extra_len > 0) {
+        header.extra     = extra;
+        header.extra_len = (uInt)extra_len;
+        header.extra_max = (uInt)extra_len;
+    }
+
+    /* 이 호출을 하면 FEXTRA 플래그가 켜지고,
+       우리가 넣은 extra field 가 gzip 헤더에 기록됨 */
+    ret = deflateSetHeader(&strm, &header);
+    if (ret != Z_OK) {
+        deflateEnd(&strm);
+        return ret;
+    }
+
+    /* 일반적인 deflate 루프 */
+    int flush;
+    do {
+        strm.avail_in = (uInt)fread(in, 1, CHUNK, source);
+        if (ferror(source)) {
+            deflateEnd(&strm);
+            return Z_ERRNO;
+        }
+        flush = feof(source) ? Z_FINISH : Z_NO_FLUSH;
+        strm.next_in = in;
+
+        do {
+            strm.avail_out = CHUNK;
+            strm.next_out  = out;
+
+            ret = deflate(&strm, flush);
+            if (ret == Z_STREAM_ERROR) {
+                deflateEnd(&strm);
+                return ret;
+            }
+
+            have = CHUNK - strm.avail_out;
+            if (fwrite(out, 1, have, dest) != have || ferror(dest)) {
+                deflateEnd(&strm);
+                return Z_ERRNO;
+            }
+        } while (strm.avail_out == 0);
+
+    } while (flush != Z_FINISH);
+
+    deflateEnd(&strm);
+    return Z_OK;
+}
+
+/* -------------------------------------------------------
+ * main: 사용법
+ *   minigzip_meta <input> <output.gz> [author] [date]
+ * ----------------------------------------------------- */
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        fprintf(stderr,
+                "usage: %s <input> <output.gz> [author] [date]\n",
+                argv[0]);
+        return 1;
+    }
+
+    const char *in_name  = argv[1];
+    const char *out_name = argv[2];
+    const char *author   = (argc >= 4) ? argv[3] : "unknown";
+    const char *date     = (argc >= 5) ? argv[4] : "unknown";
+
+    FILE *in  = fopen(in_name, "rb");
+    if (!in) {
+        perror("open input");
+        return 1;
+    }
+    FILE *out = fopen(out_name, "wb");
+    if (!out) {
+        perror("open output");
+        fclose(in);
+        return 1;
+    }
+
+    int ret = deflate_with_meta(in, out, author, date);
+
+    fclose(in);
+    fclose(out);
+
+    if (ret != Z_OK) {
+        fprintf(stderr, "compression failed: %d\n", ret);
+        return 1;
+    }
+
+    printf("created %s with author='%s', date='%s'\n",
+           out_name, author, date);
+    return 0;
+}

--- a/test/minigzip_meta.c
+++ b/test/minigzip_meta.c
@@ -1,0 +1,189 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "zlib.h"
+
+#define CHUNK 16384  /* 한 번에 읽고 쓰는 버퍼 크기 */
+
+/* build_extra: gzip 헤더의 extra 필드(FEXTRA 영역)에 AU(Author), DT(Date) 메타데이터를 작성하는 함수 */
+
+static size_t build_extra(unsigned char *buf, size_t max,
+                          const char *author, const char *date)
+{
+    unsigned char *p = buf;
+    uint16_t xlen = 0;
+
+    if (max < 2) {
+        return 0;
+    }
+
+    // 나중에 XLEN을 채우기 위해 2바이트 비워둠
+    p += 2;
+
+    // 1) AU 필드: 작성자 정보
+    if (author && author[0] != '\0') {
+        size_t len = strlen(author);
+        if (max - (size_t)(p - buf) >= 4 + len) {
+            *p++ = 'A';
+            *p++ = 'U';
+            uint16_t L = (uint16_t)len;
+            *p++ = (unsigned char)(L & 0xff);      // 길이 low byte
+            *p++ = (unsigned char)((L >> 8) & 0xff); // 길이 high byte
+            memcpy(p, author, len);
+            p += len;
+            xlen += (uint16_t)(4 + len);
+        }
+    }
+
+    // 2) DT 필드: 날짜 정보
+    if (date && date[0] != '\0') {
+        size_t len = strlen(date);
+        if (max - (size_t)(p - buf) >= 4 + len) {
+            *p++ = 'D';
+            *p++ = 'T';
+            uint16_t L = (uint16_t)len;
+            *p++ = (unsigned char)(L & 0xff);
+            *p++ = (unsigned char)((L >> 8) & 0xff);
+            memcpy(p, date, len);
+            p += len;
+            xlen += (uint16_t)(4 + len);
+        }
+    }
+
+    // 맨 앞 2바이트에 XLEN 값 채워 넣기 (little endian)
+    buf[0] = (unsigned char)(xlen & 0xff);
+    buf[1] = (unsigned char)((xlen >> 8) & 0xff);
+
+    return (size_t)(p - buf);  // extra 전체 길이 (XLEN 포함)
+}
+
+
+/* deflate_with_meta: source 파일을 gzip 포맷으로 압축하면서 gzip 헤더에 meta(author, date)를 넣는 함수 */
+static int deflate_with_meta(FILE *source, FILE *dest,
+                             const char *author, const char *date)
+{
+    int ret;
+    unsigned have;
+    z_stream strm;
+    unsigned char in[CHUNK];
+    unsigned char out[CHUNK];
+
+    // z_stream 초기화
+    memset(&strm, 0, sizeof(strm));
+    strm.zalloc = Z_NULL;
+    strm.zfree  = Z_NULL;
+    strm.opaque = Z_NULL;
+
+    // 15 + 16 : 15비트 윈도우 + gzip 사용 플래그(16) → gzip 포맷으로 압축
+    ret = deflateInit2(&strm,
+                       Z_DEFAULT_COMPRESSION,
+                       Z_DEFLATED,
+                       15 + 16,
+                       8,
+                       Z_DEFAULT_STRATEGY);
+    if (ret != Z_OK) {
+        return ret;
+    }
+
+    // gzip 헤더 설정
+    gz_header header;
+    memset(&header, 0, sizeof(header));
+
+    header.os = 3;  // 운영체제 코드(3 = UNIX)
+
+    // extra 버퍼에 메타데이터 채우기
+    unsigned char extra[256];
+    size_t extra_len = build_extra(extra, sizeof(extra), author, date);
+
+    if (extra_len > 0) {
+        header.extra     = extra;
+        header.extra_len = (uInt)extra_len;
+        header.extra_max = (uInt)extra_len;
+    }
+
+    // 헤더를 스트림에 세팅
+    // 이렇게 하면 FEXTRA 비트가 켜지고 우리가 만든 extra field가 gzip 헤더에 들어감
+    ret = deflateSetHeader(&strm, &header);
+    if (ret != Z_OK) {
+        deflateEnd(&strm);
+        return ret;
+    }
+
+    // deflate 루프 
+    int flush;
+    do {
+        strm.avail_in = (uInt)fread(in, 1, CHUNK, source);
+        if (ferror(source)) {
+            deflateEnd(&strm);
+            return Z_ERRNO;
+        }
+        flush = feof(source) ? Z_FINISH : Z_NO_FLUSH;
+        strm.next_in = in;
+
+        do {
+            strm.avail_out = CHUNK;
+            strm.next_out  = out;
+
+            ret = deflate(&strm, flush);
+            if (ret == Z_STREAM_ERROR) {
+                deflateEnd(&strm);
+                return ret;
+            }
+
+            have = CHUNK - strm.avail_out;
+            if (fwrite(out, 1, have, dest) != have || ferror(dest)) {
+                deflateEnd(&strm);
+                return Z_ERRNO;
+            }
+        } while (strm.avail_out == 0);
+
+    } while (flush != Z_FINISH);
+
+    deflateEnd(&strm);
+    return Z_OK;
+}
+
+/* main 사용 방법: minigzip_meta <input> <output.gz> [author] [date] */
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        fprintf(stderr,
+                "usage: %s <input> <output.gz> [author] [date]\n",
+                argv[0]);
+        return 1;
+    }
+
+    const char *in_name  = argv[1];
+    const char *out_name = argv[2];
+    const char *author   = (argc >= 4) ? argv[3] : "unknown";
+    const char *date     = (argc >= 5) ? argv[4] : "unknown";
+
+    FILE *in  = fopen(in_name, "rb");
+    if (!in) {
+        perror("open input");
+        return 1;
+    }
+    FILE *out = fopen(out_name, "wb");
+    if (!out) {
+        perror("open output");
+        fclose(in);
+        return 1;
+    }
+    
+    // 실제 압축 + 메타데이터 삽입 작업 호출
+    int ret = deflate_with_meta(in, out, author, date);
+
+    fclose(in);
+    fclose(out);
+
+    if (ret != Z_OK) {
+        fprintf(stderr, "compression failed: %d\n", ret);
+        return 1;
+    }
+
+    printf("created %s with author='%s', date='%s'\n",
+           out_name, author, date);
+    return 0;
+}


### PR DESCRIPTION
## Feature: gzip 헤더 FEXTRA에 사용자 메타데이터 기록

`zlib` 예제 프로그램에 **gzip 헤더의 FEXTRA(Extra field) 영역에 사용자 지정 메타데이터를 기록하는 기능** 추가

- 새 예제 파일: `test/minigzip_meta.c`
- 기능
  - gzip 헤더에 **작성자(Author)** 와 **날짜(Date)** 정보를 저장
  - Extra field 안에 다음과 같은 서브 필드를 사용
    - `AU` : Author 문자열
    - `DT` : Date 문자열

---

## 빌드 및 실행 방법

> 환경: 리눅스, zlib 소스가 `~/zlib` 에 클론되어 있다고 가정

### 1) zlib 빌드 (처음 한 번만)

```bash
cd ~/zlib
ls
# configure  Makefile.in  zlib.h  test/ ... 가 보이면 OK

./configure
make

ls libz.a
# libz.a  라고 보이면 빌드 완료
```

### 2) 예제 컴파일
```bash
cd ~/zlib/test
ls
# example.c, minigzip.c, minigzip_meta.c ... 가 있어야 함

gcc -I.. -o minigzip_meta minigzip_meta.c ../libz.a

ls minigzip_meta
# minigzip_meta* 처럼 보이고, 초록색(실행 파일)이면 OK
```

### 3) 입력 파일 만들기
```bash
echo "hello gzip meta test" > input.txt
ls
# input.txt  minigzip_meta ... 처럼 보이면 됨
```

### 4) 프로그램 실행
```bash
./minigzip_meta input.txt output.gz "C389033" "2025-11-24"
# 정상 실행 시:
# created output.gz with author='C389033', date='2025-11-24'
```
### 5) 결과 및 헤더 확인
```bash
ls
# input.txt  output.gz  minigzip_meta ... 처럼 output.gz 파일이 생성됨

gzip -dc output.gz
# 화면에 "hello gzip meta test" 가 출력되면 압축/해제는 정상 동작

hexdump -C output.gz | head
# 헤더 영역에서 'AU', 'DT' 와 함께 "C389033", "2025-11-24" 문자열이 들어간 것을 확인할 수 있음
```
