### PR TITLE
CMake: Changing include directory scope to private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,9 @@ if(MINGW)
 endif(MINGW)
 
 add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-target_include_directories(zlib PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(zlib PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
-target_include_directories(zlibstatic PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(zlibstatic PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
 set_target_properties(zlib PROPERTIES SOVERSION 1)
 


### PR DESCRIPTION
We include zlib as a submodule. When trying to build v1.3.1 (or master) we get the following error message:
<img width="739" height="134" alt="grafik" src="https://github.com/user-attachments/assets/ff514958-f791-4e7e-8fcb-fe22973e0a66" />

[This ticket](https://discourse.cmake.org/t/i-cant-understand-an-error-about-interface-sources-and-prefix/10105/6) mentioned the scope of the include directories might be the issue.

When changing the scope from public to private our project built again.

We can also build running v1.3.0.