### PR TITLE
Always include errno.h on Unix

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -128,8 +128,8 @@
 #  include <windows.h>
 #  define zstrerror() gz_strwinerror((DWORD)GetLastError())
 #else
+#  include <errno.h>
 #  ifndef NO_STRERROR
-#    include <errno.h>
 #    define zstrerror() strerror(errno)
 #  else
 #    define zstrerror() "stdio error (consult errno)"


### PR DESCRIPTION
We are using `errno` unconditionally in gzread and gzwrite.

This is failing on aarch64 (for the LLVM CI
https://lab.llvm.org/buildbot/#/builders/51/builds/28255/steps/8/logs/stdio): 

```
/home/b/sanitizer-aarch64-linux/build/build_default/bin/clang -march=armv8-a -fPIC -flto -Oz -g0 -DNDEBUG -target aarch64-unknown-linux-gnu -Wn
o-unused-command-line-argument -include /home/b/sanitizer-aarch64-linux/build/llvm-project/compiler-rt/lib/sanitizer_common/symbolizer/../sanit
izer_redefine_builtins.h -DSANITIZER_COMMON_REDEFINE_BUILTINS_IN_STD -Wno-language-extension-token -Wno-deprecated-non-prototype -fPIC -D_LARGE
FILE64_SOURCE=1 -DNO_STRERROR -DNO_vsnprintf -DHAVE_HIDDEN  -c -o gzwrite.o gzwrite.c
[...]
gzwrite.c:111:17: error: use of undeclared identifier 'errno'
  111 |                 errno = 0;
      |                 ^~~~~
```