### PR TITLE
Restore necessary type cast

### DIFF
--- a/gzread.c
+++ b/gzread.c
@@ -412,7 +412,7 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
     }
 
     /* read len or fewer bytes to buf */
-    len = gz_read(state, buf, len);
+    len = (unsigned)gz_read(state, buf, len);
 
     /* check for an error */
     if (len == 0) {


### PR DESCRIPTION
https://github.com/madler/zlib/blob/570720b0c24f9686c33f35a1b3165c1f568b96be/gzread.c#L415
Visual Studio emits warning for 64-bit code:  `C4267: '=': conversion from 'size_t' to 'unsigned int', possible loss of data`
This cast existed in 1.3.1, but had been removed in recent commit `Support non-blocking devices in the gz* routines.`