### PR TITLE
Add Windows ARM64 support to the CI workflows

### DIFF
--- a/.github/workflows/c-std.yml
+++ b/.github/workflows/c-std.yml
@@ -27,6 +27,10 @@ jobs:
             value: windows-latest
             cmake-opt: -G Ninja
 
+          - name: Windows ARM64
+            value: windows-11-arm
+            cmake-opt: -G Ninja
+
         compiler:
           - gcc
           - clang
@@ -90,9 +94,21 @@ jobs:
           - { os:   { name: Windows },
               builder: configure }
 
+            # Don't run configure on Windows ARM64
+          - { os:   { name: Windows ARM64 },
+              builder: configure }
+
             # Don't run gcc 32-bit on Windows
           - { os:   { name: Windows },
               arch: { tag:  i386  } }
+
+            # Don't run 32 bit on Windows ARM64
+          - { os:   { name: Windows ARM64 },
+              arch: { tag:  i386  } }
+
+            # Don't run gcc on Windows ARM64
+          - { os:   { name: Windows ARM64 },
+              compiler: gcc }
 
     steps:
 
@@ -169,6 +185,9 @@ jobs:
           - name: Windows
             value: windows-latest
 
+          - name: Windows ARM64
+            value: windows-11-arm
+
         compiler:
           - cl
 
@@ -178,6 +197,9 @@ jobs:
 
           - name: 64-bit
             value: -A x64
+
+          - name: ARM64
+            value: -A ARM64
 
         builder:
           - cmake
@@ -198,6 +220,19 @@ jobs:
 
           - name: latest
             value: /std:clatest
+
+        exclude:
+          # Don't run 32-bit on Windows ARM64
+          - { os:   { name: Windows ARM64 },
+              arch: { name: 32-bit } }
+
+          # Don't run x64 on Windows ARM64
+          - { os:   { name: Windows ARM64 },
+              arch: { name: 64-bit } }
+
+          # Don't run ARM64 on regular Windows
+          - { os:   { name: Windows },
+              arch: { name: ARM64 } }
 
     steps:
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,6 +51,13 @@ jobs:
             cmake-args: -A x64 -DMINIZIP_ENABLE_BZIP2=OFF
             pkgtgt: PACKAGE
 
+          - name: Windows MSVC ARM64
+            os: windows-11-arm
+            compiler: cl
+            cflags: /W3
+            cmake-args: -A ARM64 -DMINIZIP_ENABLE_BZIP2=OFF
+            pkgtgt: PACKAGE
+
           - name: Windows GCC
             os: windows-latest
             compiler: gcc

--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -4,11 +4,14 @@ on: [push, pull_request]
 
 jobs:
   MSys:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os || 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:
-        sys: [mingw32, mingw64, ucrt64, clang64]
+        sys: [mingw32, mingw64, ucrt64, clang64, clangarm64]
+        include:
+          - sys: clangarm64
+            os: windows-11-arm
     name: MSys - ${{ matrix.sys }}
     defaults:
       run:


### PR DESCRIPTION
This PR updates the C standard, CMake, and MSYS CI workflows to run on Windows 11 ARM.

- Extend the C standard CI workflow to support Windows 11 ARM.
- Add MSVC ARM64 build configurations to the CMake CI workflow.
- Enable clangarm64 support in the MSYS CI job on Windows ARM.
- Introduce compiler and architecture exclusion rules to avoid unsupported combinations (for example, 32-bit builds and GCC on Windows ARM64).