### PR TITLE
Mingw clang64 test should really use clang

### DIFF
--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -36,6 +36,7 @@ jobs:
           -B build \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_BUILD_TYPE=Release \
+          -DZLIB_BUILD_MINIZIP=ON \
           -DMINIZIP_ENABLE_BZIP2=ON
     - name: Configure clang64
       if: matrix.sys == 'clang64'
@@ -45,6 +46,7 @@ jobs:
           -B build \
           -DCMAKE_VERBOSE_MAKEFILE=ON \
           -DCMAKE_BUILD_TYPE=Release \
+          -DZLIB_BUILD_MINIZIP=ON \
           -DMINIZIP_ENABLE_BZIP2=ON
     - name: Build
       run: cmake --build build --config Release

--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -29,8 +29,18 @@ jobs:
           toolchain:p
           cmake:p
     - name: Configure
+      if: matrix.sys != 'clang64'
       run: |
         cmake -G"Unix Makefiles" \
+          -S . \
+          -B build \
+          -DCMAKE_VERBOSE_MAKEFILE=ON \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DMINIZIP_ENABLE_BZIP2=ON
+    - name: Configure clang64
+      if: matrix.sys == 'clang64'
+      run: |
+        CC=clang cmake -G"Unix Makefiles" \
           -S . \
           -B build \
           -DCMAKE_VERBOSE_MAKEFILE=ON \


### PR DESCRIPTION
I don't know why, but on clang64-mingw gcc is also available, so now CC=clang is explicitly set.
And also minizip is tested on mingw, not only cygwin.