### PR TITLE
zutil: fix integer overflow in zcalloc()

### DIFF
--- a/zutil.c
+++ b/zutil.c
@@ -9,6 +9,8 @@
 #ifndef Z_SOLO
 #  include "gzguts.h"
 #endif
+#include <stddef.h> /* size_t */
+#include <limits.h> /* SIZE_MAX */
 
 z_const char * const z_errmsg[10] = {
     (z_const char *)"need dictionary",     /* Z_NEED_DICT       2  */
@@ -291,9 +293,25 @@ extern voidp calloc(uInt items, uInt size);
 extern void free(voidpf ptr);
 #endif
 
+static int z_size_mul_overflow_(size_t a, size_t b, size_t *out) {
+    if (a == 0 || b == 0) {
+        *out = 0;
+        return 0;
+    }
+    if (a > SIZE_MAX / b)
+        return 1;
+    *out = a * b;
+    return 0;
+}
+
 voidpf ZLIB_INTERNAL zcalloc(voidpf opaque, unsigned items, unsigned size) {
     (void)opaque;
-    return sizeof(uInt) > 2 ? (voidpf)malloc(items * size) :
+
+    size_t n = 0;
+    if (z_size_mul_overflow_((size_t)items, (size_t)size, &n))
+        return Z_NULL;
+
+    return sizeof(uInt) > 2 ? (voidpf)malloc(n) :
                               (voidpf)calloc(items, size);
 }
 


### PR DESCRIPTION
## Summary

This patch fixes an integer overflow vulnerability in zlib’s internal allocator helper `zcalloc()` that could result in undersized heap allocations and subsequent heap corruption.

## Vulnerability Details

`zcalloc(voidpf opaque, unsigned items, unsigned size)` computed the total
allocation size using `items * size` without overflow checks. If this
multiplication wrapped, `malloc()` could return a buffer smaller than
the logical allocation size expected by zlib internals.

Subsequent writes during table initialization or decompression state
setup could then write past the end of the allocated buffer, corrupting
heap memory.

## Fix

* Added overflow-checked multiplication for `size_t`
* Updated `zcalloc()` to detect overflow when computing `items * size`
* On overflow, `zcalloc()` returns `Z_NULL` to force a controlled
  allocation failure

This prevents the root cause (integer wraparound) rather than attempting
to guard individual write sites.

## Impact

* Prevents heap buffer overflows caused by undersized allocations
* Converts a potentially exploitable memory corruption into a safe
  `Z_MEM_ERROR` path
* No behavioral changes for valid allocation sizes

## Testing

* Verified normal allocations behave identically when sizes are valid
* Forced overflow cases correctly return `Z_NULL`
* No regressions observed in standard compression/decompression paths

This change improves memory safety without altering zlib’s public API or
expected behavior.
