### PR TITLE
Fixed OS_CODE redefinition on macos

### DIFF
--- a/zutil.h
+++ b/zutil.h
@@ -161,7 +161,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  define OS_CODE 18
 #endif
 
-#ifdef __APPLE__
+#ifdef __APPLE__ || defined(TARGET_OS_MAC)
 #  define OS_CODE 19
 #endif
 


### PR DESCRIPTION
According to system mappings documented in the PKWare APPNOTE.TXT version 6.3.4, section 4.4.2.2, OS_CODE 7 is for Macintosh and OS_CODE 19 is for OSX (Darwin). Xcode sdk defines TARGET_OS_MAC for ALL darwin platforms (including iOS, for example), as such it makes sense to use it for OS_CODE 19 (along with newer __APPLE__ define)
