### PR TITLE
Clean missing-variable-declarations warnings

### DIFF
--- a/contrib/infback9/inftree9.c
+++ b/contrib/infback9/inftree9.c
@@ -8,6 +8,10 @@
 
 #define MAXBITS 15
 
+#ifdef __GNUC__
+__attribute__((used))
+static
+#endif
 const char inflate9_copyright[] =
    " inflate9 1.3.1.2 Copyright 1995-2025 Mark Adler ";
 /*

--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -109,7 +109,10 @@
 #define SIZECENTRALDIRITEM (0x2e)
 #define SIZEZIPLOCALHEADER (0x1e)
 
-
+#ifdef __GNUC__
+__attribute__((used))
+static
+#endif
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -93,7 +93,12 @@
 #  define DEF_MEM_LEVEL  MAX_MEM_LEVEL
 #endif
 #endif
-const char zip_copyright[] =" zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+#ifdef __GNUC__
+__attribute__((used))
+static
+#endif
+const char zip_copyright[] =
+   " zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
 
 #define SIZEDATA_INDATABLOCK (4096-(4*4))

--- a/deflate.c
+++ b/deflate.c
@@ -51,6 +51,10 @@
 
 #include "deflate.h"
 
+#ifdef __GNUC__
+__attribute__((used))
+static
+#endif
 const char deflate_copyright[] =
    " deflate 1.3.1.2 Copyright 1995-2025 Jean-loup Gailly and Mark Adler ";
 /*

--- a/inftrees.c
+++ b/inftrees.c
@@ -18,6 +18,10 @@
 
 #define MAXBITS 15
 
+#ifdef __GNUC__
+__attribute__((used))
+static
+#endif
 const char inflate_copyright[] =
    " inflate 1.3.1.2 Copyright 1995-2025 Mark Adler ";
 /*


### PR DESCRIPTION
Add \_\_attribute__((used)) and static qualifier to copyright strings in deflate.c, inftrees.c, zip.c, unzip.c, and inftree9.c to resolve missing-variable-declarations compiler warnings while preserving copyright strings in compiled binaries.