### PR TITLE
Add -static-libgcc to mingw build

### DIFF
--- a/win32/Makefile.gcc
+++ b/win32/Makefile.gcc
@@ -88,7 +88,7 @@ $(STATICLIB): $(OBJS) $(OBJA)
 $(IMPLIB): $(SHAREDLIB)
 
 $(SHAREDLIB): win32/zlib.def $(OBJS) $(OBJA) zlibrc.o
-	$(CC) -shared -Wl,--out-implib,$(IMPLIB) $(LDFLAGS) \
+	$(CC) -shared -static-libgcc -Wl,--out-implib,$(IMPLIB) $(LDFLAGS) \
 	-o $@ win32/zlib.def $(OBJS) $(OBJA) zlibrc.o
 	$(STRIP) $@
 


### PR DESCRIPTION
After Tcl upgraded to zlib-1.3.1.2, [this](https://core.tcl-lang.org/tcl/tktview/1b6f81955c) ticket is raised.

When (cross-)compiling zlib1.dll with gcc-13.4, the i686 dll has a dependency on libgcc_s_sjlj-1.dll:

Import from module libgcc_s_sjlj-1.dll :
         Function __moddi3

This means, zlib1.dll cannot simply be taken out to another environment without copying libgcc_s_sjlj-1.dll as well. That's not desirable. Therefore I suggest to add the -static-libgcc option to the mingw build. That fixes the problem.