### PR TITLE
contrib/minizip: install ints.h

### DIFF
--- a/contrib/minizip/Makefile.am
+++ b/contrib/minizip/Makefile.am
@@ -27,6 +27,7 @@ libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
 minizip_includedir = $(includedir)/minizip
 minizip_include_HEADERS = \
 	crypt.h \
+	ints.h \
 	ioapi.h \
 	mztools.h \
 	unzip.h \


### PR DESCRIPTION
`contrib/minizip/ioapi.h` includes `ints.h`, but `contrib/minizip/Makefile.am` does not install that header.

This causes downstream build failures for installed minizip headers (e.g. includes of `<minizip/unzip.h>` pulling in `ioapi.h`).

This PR adds `ints.h` to `minizip_include_HEADERS` so `make install` installs a complete public header set.

Fixes #1164

Downstream context: https://github.com/Homebrew/homebrew-core/pull/267954