### PR TITLE
If configure detects vsnprintf(3), use it

### DIFF
--- a/configure
+++ b/configure
@@ -762,6 +762,8 @@ EOF
 
     if try $CC -c $CFLAGS $test.c; then
       echo "Checking for return value of vsnprintf()... Yes." | tee -a configure.log
+      CFLAGS="$CFLAGS -DHAS_vsnprintf"
+      SFLAGS="$SFLAGS -DHAS_vsnprintf"
     else
       CFLAGS="$CFLAGS -DHAS_vsnprintf_void"
       SFLAGS="$SFLAGS -DHAS_vsnprintf_void"

--- a/gzguts.h
+++ b/gzguts.h
@@ -92,8 +92,8 @@
 #        define vsnprintf _vsnprintf
 #      endif
 #    endif
-#  elif !defined(__STDC_VERSION__) || __STDC_VERSION__-0 < 199901L
-/* Otherwise if C89/90, assume no C99 snprintf() or vsnprintf() */
+#  elif (!defined(__STDC_VERSION__) || __STDC_VERSION__-0 < 199901L) && !defined(HAS_vsnprintf)
+/* Otherwise if C89/90, assume no C99 snprintf() or vsnprintf() unless configure detected it */
 #    ifndef NO_snprintf
 #      define NO_snprintf
 #    endif


### PR DESCRIPTION
vsnprintf() & snprintf() can be found as far back as [4.3BSD Net/2](https://www.tuhs.org/cgi-bin/utree.pl?file=Net2/usr/src/lib/libc/stdio). Building on an operating system of such vintage, you're likely going to have a compiler that support C89 at most or defaults to it (GCC 3.x). This change allows gzwrite.c to be built on early Mac OS X releases with vsnprintf() support. Tested on Mac OS X 10.2 with GCC 3.1 but confirmed [10.0 shipped with vsnprintf() & snprintf()](https://github.com/apple-oss-distributions/Libc/tree/Libc-166/stdio.subproj).

Test suite on OS X 10.2 also now passes
```
hello world
zlib version 1.3.2 = 0x1320, compile flags = 0x95
uncompress(): hello, hello!
gzread(): hello, hello!
gzgets() after gzseek:  hello!
inflate(): hello, hello!
large_inflate(): OK
after inflateSync(): hello, hello!
inflate with dictionary: hello, hello!
                *** zlib test OK ***
hello world
zlib version 1.3.2 = 0x1320, compile flags = 0x95
uncompress(): hello, hello!
gzread(): hello, hello!
gzgets() after gzseek:  hello!
inflate(): hello, hello!
large_inflate(): OK
after inflateSync(): hello, hello!
inflate with dictionary: hello, hello!
                *** zlib shared test OK ***
```
Whereas before it would fail:
```
hello world
zlib version 1.3.2 = 0x1320, compile flags = 0x8000095 uncompress(): hello, hello!
gzprintf err:
                *** zlib test FAILED ***
```
