### PR TITLE
fix: Add missing replacement of VGFMAFLAG in configure

### DIFF
--- a/configure
+++ b/configure
@@ -1024,6 +1024,7 @@ sed < ${SRCDIR}Makefile.in "
 /^LDFLAGS *=/s#=.*#=$LDFLAGS#
 /^LDSHARED *=/s#=.*#=$LDSHARED#
 /^CPP *=/s#=.*#=$CPP#
+/^VGFMAFLAG *=/s#=.*#=$VGFMAFLAG#
 /^STATICLIB *=/s#=.*#=$STATICLIB#
 /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#
 /^SHAREDLIBV *=/s#=.*#=$SHAREDLIBV#
@@ -1054,6 +1055,7 @@ sed < ${SRCDIR}zlib.pc.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#
 /^CPP *=/s#=.*#=$CPP#
+/^VGFMAFLAG *=/s#=.*#=$VGFMAFLAG#
 /^LDSHARED *=/s#=.*#=$LDSHARED#
 /^STATICLIB *=/s#=.*#=$STATICLIB#
 /^SHAREDLIB *=/s#=.*#=$SHAREDLIB#


### PR DESCRIPTION
The variable VGFMAFLAG is set in the configure script, but will not be exported to the Makefile. Therefore, builds on s390x will fail.

```
cc -O2 -fomit-frame-pointer -pipe  -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_S390X_VX  -c -o gzwrite.o gzwrite.c
cc -O2 -fomit-frame-pointer -pipe  -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_S390X_VX   -c -o crc32_vx.o contrib/crc32vx/crc32_vx.c
In file included from contrib/crc32vx/crc32_vx.c:20:
contrib/crc32vx/crc32_vx.c: In function 'crc32_le_vgfm_16':
contrib/crc32vx/crc32_vx.c:79:17: error: '__builtin_s390_vec_insert' requires '-mvx'
   79 |     v0 = (uv2di)vec_insert(crc, (uv4si)v0, 3);
      |                 ^~~~~~~~~~
contrib/crc32vx/crc32_vx.c:82:16: error: '__builtin_s390_vec_perm' requires '-mvx'
...
```

This patch adds the missing replacements.