### PR TITLE
Remove C99 intermingled variable declarations from minizip

### DIFF
--- a/contrib/minizip/skipset.h
+++ b/contrib/minizip/skipset.h
@@ -91,10 +91,12 @@ void set_uniq(set_rand_t *gen, const void *ptr) {
 }
 /* Return 32 random bits, advancing the state *gen. */
 ui32_t set_rand(set_rand_t *gen) {
+    ui32_t mix;
+    int rot;
     ui64_t state = gen->state;
     gen->state = state * 6364136223846793005ULL + gen->inc;
-    ui32_t mix = (ui32_t)(((state >> 18) ^ state) >> 27);
-    int rot = state >> 59;
+    mix = (ui32_t)(((state >> 18) ^ state) >> 27);
+    rot = state >> 59;
     return (mix >> rot) | (mix << ((-rot) & 31));
 }
 /* End of PCG32 code. */
@@ -185,6 +187,7 @@ void set_free(set_t *set, void *ptr) {
 // setting them to set->head if not previously filled in. Otherwise it is
 // assumed that the first want links are about to be filled in. */
 void set_grow(set_t *set, set_node_t *node, int want, int fill) {
+    int i;
     if (node->size < want) {
         int more = node->size ? node->size : 1;
         while (more < want)
@@ -193,7 +196,6 @@ void set_grow(set_t *set, set_node_t *node, int want, int fill) {
                                 (size_t)more * sizeof(set_node_t *));
         node->size = (i16_t)more;
     }
-    int i;
     if (fill)
         for (i = node->fill; i < want; i++)
             node->right[i] = set->head;
@@ -298,11 +300,14 @@ void set_end(set_t *set) {
 /* Look for key. Return 1 if found or 0 if not. This also puts the path to get
 // there in set->path, for use by set_insert(). */
 int set_found(set_t *set, set_key_t key) {
+    set_node_t *head, *here;
+    int i;
     assert(set_ok(set) && "improper use");
 
     /* Start at depth and work down and right as determined by key comparisons. */
-    set_node_t *head = set->head, *here = head;
-    int i = set->depth;
+    head = set->head;
+    here = head;
+    i = set->depth;
     set_grow(set, set->path, i + 1, 0);
     do {
         while (here->right[i] != head &&
@@ -318,6 +323,9 @@ int set_found(set_t *set, set_key_t key) {
 
 /* Insert the key key. Return 0 on success, or 1 if key is already in the set. */
 int set_insert(set_t *set, set_key_t key) {
+    int level = 0;
+    int bit;
+    int i;
     assert(set_ok(set) && "improper use");
 
     if (set_found(set, key))
@@ -326,12 +334,11 @@ int set_insert(set_t *set, set_key_t key) {
 
     /* Randomly generate a new level-- level 0 with probability 1/2, 1 with
     // probability 1/4, 2 with probability 1/8, etc. */
-    int level = 0;
     for (;;) {
         if (set->ran == 1)
             /* Ran out. Get another 32 random bits. */
             set->ran = set_rand(&set->gen) | (1ULL << 32);
-        int bit = set->ran & 1;
+        bit = set->ran & 1;
         set->ran >>= 1;
         if (bit)
             break;
@@ -351,7 +358,6 @@ int set_insert(set_t *set, set_key_t key) {
     set->node = set_node(set);
     set->node->key = key;
     set_grow(set, set->node, level + 1, 0);
-    int i;
     for (i = 0; i <= level; i++) {
         set->node->right[i] = set->path->right[i]->right[i];
         set->path->right[i]->right[i] = set->node;

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -367,6 +367,7 @@ local long block_get2(block_t *block) {
 /* Read up to len bytes from block into buf. Return the number of bytes read. */
 local size_t block_read(block_t *block, unsigned char *buf, size_t len) {
     size_t need = len;
+    size_t take;
     while (need) {
         if (block->left == 0) {
             /* Get a byte to update and step through the linked list as needed. */
@@ -378,7 +379,7 @@ local size_t block_read(block_t *block, unsigned char *buf, size_t len) {
             need--;
             continue;
         }
-        size_t take = need > block->left ? block->left : need;
+        take = need > block->left ? block->left : need;
         memcpy(buf, block->next, take);
         block->next += take;
         block->left -= take;
@@ -408,6 +409,7 @@ local int block_skip(block_t *block, size_t n) {
 // zero-terminated file name, or NULL for end of input or invalid data. If
 // invalid, *block is marked bad. This uses *set for the allocation of memory. */
 local char *block_central_name(block_t *block, set_t *set) {
+    unsigned flen, xlen, clen;
     char *name = NULL;
     for (;;) {
         if (block_end(block))
@@ -423,9 +425,9 @@ local char *block_central_name(block_t *block, set_t *set) {
         /* Go through the remaining fixed-length portion of the record,
         // extracting the lengths of the three variable-length fields. */
         block_skip(block, 24);
-        unsigned flen = (unsigned)block_get2(block);    /* file name length */
-        unsigned xlen = (unsigned)block_get2(block);    /* extra length */
-        unsigned clen = (unsigned)block_get2(block);    /* comment length */
+        flen = (unsigned)block_get2(block);    /* file name length */
+        xlen = (unsigned)block_get2(block);    /* extra length */
+        clen = (unsigned)block_get2(block);    /* comment length */
         if (block_skip(block, 12) == -1)
             /* Premature end of the record. */
             break;
@@ -463,6 +465,9 @@ local char *block_central_name(block_t *block, set_t *set) {
 // the central directory is invalid, -2 if out of memory, or ZIP_PARAMERROR if
 // file is NULL. */
 extern int ZEXPORT zipAlreadyThere(zipFile file, char const *name) {
+    size_t len;
+    char *copy;
+    int found;
     zip64_internal *zip = file;
     if (zip == NULL)
         return ZIP_PARAMERROR;
@@ -501,10 +506,10 @@ extern int ZEXPORT zipAlreadyThere(zipFile file, char const *name) {
     }
 
     /* Return true if name is in the central directory. */
-    size_t len = strlen(name);
-    char *copy = set_alloc(&zip->set, NULL, len + 1);
+    len = strlen(name);
+    copy = set_alloc(&zip->set, NULL, len + 1);
     memcpy(copy, name, len + 1);
-    int found = set_found(&zip->set, copy);
+    found = set_found(&zip->set, copy);
     set_free(&zip->set, copy);
     return found;
 }


### PR DESCRIPTION
Hello,

This is a small patch to remove intermingled variable declarations from minizip, which prevents build on older compilers (notably Microsoft Visual Studio 2008 that doesn't support C99).

Kind Regards,
Sébastien-