### PR TITLE
Solaris supportability fixes

### DIFF
--- a/configure
+++ b/configure
@@ -150,7 +150,7 @@ case "$1" in
     --sysconfdir=*) echo "ignored option: --sysconfdir" | tee -a configure.log; shift ;;
     --localstatedir=*) echo "ignored option: --localstatedir" | tee -a configure.log; shift ;;
     -c* | --const) zconst=1; shift ;;
-    -w* | --warn) warn=$((warn + 1)); shift ;;
+    -w* | --warn) warn=`expr $warn + 1`; shift ;;
     -d* | --debug) debug=1; shift ;;
     --sanitize) address=1; shift ;;
     --address) address=1; shift ;;

--- a/gzguts.h
+++ b/gzguts.h
@@ -37,8 +37,14 @@
 #  include <limits.h>
 #endif
 
-#ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 200112L
+#ifdef __sun
+    #ifndef _POSIX_SOURCE
+        #define _POSIX_SOURCE
+    #endif
+#else
+    #ifndef _POSIX_C_SOURCE
+    #  define _POSIX_C_SOURCE 200112L
+    #endif
 #endif
 #include <fcntl.h>
 

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -15,8 +15,14 @@
 
 /* @(#) $Id$ */
 
-#ifndef _POSIX_C_SOURCE
-#  define _POSIX_C_SOURCE 200112L
+#ifdef __sun
+    #ifndef _POSIX_SOURCE
+        #define _POSIX_SOURCE
+    #endif
+#else
+    #ifndef _POSIX_C_SOURCE
+    #  define _POSIX_C_SOURCE 200112L
+    #endif
 #endif
 
 #if defined(_WIN32) && !defined(_CRT_SECURE_NO_WARNINGS)


### PR DESCRIPTION
Hello,

The changes introduced in zlib 1.3.2 have caused issues when compiling with Solaris. The Bourne shell does not support $(()) for arithmetic expressions.

The #define _POSIX_C_SOURCE 200112L also causes issues with the gcc compiler on Solaris.

With this small commit I've aimed to add a bit of the supportability back for Solaris while the behavior for the remaining platforms remain unchanged.