### PR TITLE
Minizip: fix incompatible pointer type in zipAlreadyThere

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -463,7 +463,7 @@ local char *block_central_name(block_t *block, set_t *set) {
 // the central directory is invalid, -2 if out of memory, or ZIP_PARAMERROR if
 // file is NULL. */
 extern int ZEXPORT zipAlreadyThere(zipFile file, char const *name) {
-    zip64_internal *zip = file;
+    zip64_internal *zip = (zip64_internal*)file;
     if (zip == NULL)
         return ZIP_PARAMERROR;
     if (zip->central_dir.first_block == NULL)


### PR DESCRIPTION
This fixes the following errors:

clang:
```
/zlib/contrib/minizip/zip.c:466:27: error: initialization of ‘zip64_internal *’ from incompatible pointer type ‘zipFile’ {aka ‘struct TagzipFile__ *’} [-Wincompatible-pointer-types]
  466 |     zip64_internal *zip = file;
      |                           ^~~~
```

msvc:
```
zlib\contrib\minizip\zip.c(466,21): warning C4133: 'initializing': incompatible types - from 'zipFile' to 'zip64_internal *' 
```