### PR TITLE
Fix -Wundef warnings for HAVE_UNISTD_H and HAVE_STDARG_H in zconf.h

### DIFF
--- a/configure
+++ b/configure
@@ -650,7 +650,7 @@ cat > $test.c <<EOF
 int main() { return 0; }
 EOF
 if try $CC -c $CFLAGS $test.c; then
-  sed < zconf.h "/^#if HAVE_UNISTD_H-0.* may be/s/ HAVE_UNISTD_H-0\(.*\) may be/ 1\1 was/" > zconf.temp.h
+  sed < zconf.h "/^#if defined(HAVE_UNISTD_H).* may be/s/ defined.*-0\(.*\) may be/ 1\1 was changed to/" > zconf.temp.h
   mv zconf.temp.h zconf.h
   echo "Checking for unistd.h... Yes." | tee -a configure.log
 else
@@ -665,7 +665,7 @@ cat > $test.c <<EOF
 int main() { return 0; }
 EOF
 if try $CC -c $CFLAGS $test.c; then
-  sed < zconf.h "/^#if HAVE_STDARG_H-0.* may be/s/ HAVE_STDARG_H-0\(.*\) may be/ 1\1 was/" > zconf.temp.h
+  sed < zconf.h "/^#if defined(HAVE_STDARG_H).* may be/s/ defined.*-0\(.*\) may be/ 1\1 was changed to/" > zconf.temp.h
   mv zconf.temp.h zconf.h
   echo "Checking for stdarg.h... Yes." | tee -a configure.log
 else

--- a/zconf.h
+++ b/zconf.h
@@ -443,11 +443,11 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#if HAVE_UNISTD_H-0     /* may be set to #if 1 by ./configure */
+#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H-0 /* may be #if 1 after configure */
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#if HAVE_STDARG_H-0     /* may be set to #if 1 by ./configure */
+#if defined(HAVE_STDARG_H) && HAVE_STDARG_H-0 /* may be #if 1 after configure */
 #  define Z_HAVE_STDARG_H
 #endif
 

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -443,11 +443,11 @@ typedef uLong FAR uLongf;
    typedef unsigned long z_crc_t;
 #endif
 
-#if HAVE_UNISTD_H-0     /* may be set to #if 1 by ./configure */
+#if defined(HAVE_UNISTD_H) && HAVE_UNISTD_H-0 /* may be #if 1 after configure */
 #  define Z_HAVE_UNISTD_H
 #endif
 
-#if HAVE_STDARG_H-0     /* may be set to #if 1 by ./configure */
+#if defined(HAVE_STDARG_H) && HAVE_STDARG_H-0 /* may be #if 1 after configure */
 #  define Z_HAVE_STDARG_H
 #endif
 


### PR DESCRIPTION
After 7108497fda9d4536a1afade7f42266e06dca4488, builds with -Wundef would warn when HAVE_UNISTD_H or HAVE_STDARG_H were not defined. See https://github.com/madler/zlib/issues/1169

This patch addresses that by checking that the macros are defined before checking that they are non-zero, similar to how `_LFS64_LARGEFILE` is handled.