### PR TITLE
Update adler32.c

### DIFF
--- a/adler32.c
+++ b/adler32.c
@@ -62,6 +62,10 @@ uLong ZEXPORT adler32_z(uLong adler, const Bytef *buf, z_size_t len) {
     unsigned long sum2;
     unsigned n;
 
+    /* initial Adler-32 value (deferred check for len == 1 speed) */
+    if (buf == Z_NULL)
+        return 1L;
+
     /* split Adler-32 into component sums */
     sum2 = (adler >> 16) & 0xffff;
     adler &= 0xffff;
@@ -76,10 +80,6 @@ uLong ZEXPORT adler32_z(uLong adler, const Bytef *buf, z_size_t len) {
             sum2 -= BASE;
         return adler | (sum2 << 16);
     }
-
-    /* initial Adler-32 value (deferred check for len == 1 speed) */
-    if (buf == Z_NULL)
-        return 1L;
 
     /* in case short lengths are provided, keep it somewhat fast */
     if (len < 16) {


### PR DESCRIPTION
On line 71, the program accesses memory via the pointer buf (reads buf[0]). And on line 81, it suddenly checks: if (buf == NULL).

If you pass buf = NULL to the function, the program will crash (Segmentation Fault) on line 71 before it reaches the check on line 81.
The NULL check should be at the very beginning of the function, before any attempts to read data from the array.