### PR TITLE
minizip: fix includes breakage

### DIFF
--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -110,6 +110,7 @@ unset(CMAKE_REQUIRED_FLAGS)
 set(LIBMINIZIP_SRCS ioapi.c mztools.c unzip.c zip.c)
 
 set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h mztools.h unzip.h zip.h)
+list(TRANSFORM LIBMINIZIP_HDRS PREPEND compat/ OUTPUT_VARIABLE LIBMINIZIP_HDRS_COMPAT)
 
 set(MINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> minizip.c zip.c)
 
@@ -274,6 +275,10 @@ if(MINIZIP_INSTALL)
         FILES ${LIBMINIZIP_HDRS}
         COMPONENT Development
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(
+        FILES ${LIBMINIZIP_HDRS_COMPAT}
+        COMPONENT Development
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/minizip/compat")
 endif(MINIZIP_INSTALL)
 
 if(MINIZIP_BUILD_TESTING)

--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -112,6 +112,9 @@ set(LIBMINIZIP_SRCS ioapi.c mztools.c unzip.c zip.c)
 set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h mztools.h unzip.h zip.h)
 list(TRANSFORM LIBMINIZIP_HDRS PREPEND compat/ OUTPUT_VARIABLE LIBMINIZIP_HDRS_COMPAT)
 
+set(LIBMINIZIP_PC ${minizip_BINARY_DIR}/minizip.pc)
+configure_file(${minizip_SOURCE_DIR}/minizip.pc.txt ${LIBMINIZIP_PC} @ONLY)
+
 set(MINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> minizip.c zip.c)
 
 set(MINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${WIN32}>:iowin32.h> skipset.h
@@ -279,6 +282,10 @@ if(MINIZIP_INSTALL)
         FILES ${LIBMINIZIP_HDRS_COMPAT}
         COMPONENT Development
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/minizip/compat")
+    install(
+        FILES ${LIBMINIZIP_PC}
+        COMPONENT Development
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 endif(MINIZIP_INSTALL)
 
 if(MINIZIP_BUILD_TESTING)

--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -274,7 +274,7 @@ if(MINIZIP_INSTALL)
     install(
         FILES ${LIBMINIZIP_HDRS}
         COMPONENT Development
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/minizip")
     install(
         FILES ${LIBMINIZIP_HDRS_COMPAT}
         COMPONENT Development

--- a/contrib/minizip/Makefile.am
+++ b/contrib/minizip/Makefile.am
@@ -25,13 +25,13 @@ libminizip_la_SOURCES = \
 libminizip_la_LDFLAGS = $(AM_LDFLAGS) -version-info 1:0:0 -lz
 
 minizip_includedir = $(includedir)/minizip
-minizip_include_HEADERS = \
-	crypt.h \
-	ints.h \
-	ioapi.h \
-	mztools.h \
-	unzip.h \
-	zip.h \
+nobase_minizip_include_HEADERS = \
+	crypt.h compat/crypt.h \
+	ints.h compat/ints.h \
+	ioapi.h compat/ioapi.h \
+	mztools.h compat/mztools.h \
+	unzip.h compat/unzip.h \
+	zip.h compat/zip.h \
 	${iowin32_h}
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/contrib/minizip/compat/crypt.h
+++ b/contrib/minizip/compat/crypt.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/crypt.h> instead; in future releases #include <crypt.h> will stop working"
+#include <minizip/crypt.h>

--- a/contrib/minizip/compat/ints.h
+++ b/contrib/minizip/compat/ints.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/ints.h> instead; in future releases #include <ints.h> will stop working"
+#include <minizip/ints.h>

--- a/contrib/minizip/compat/ioapi.h
+++ b/contrib/minizip/compat/ioapi.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/ioapi.h> instead; in future releases #include <ioapi.h> will stop working"
+#include <minizip/ioapi.h>

--- a/contrib/minizip/compat/mztools.h
+++ b/contrib/minizip/compat/mztools.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/mztools.h> instead; in future releases #include <mztools.h> will stop working"
+#include <minizip/mztools.h>

--- a/contrib/minizip/compat/unzip.h
+++ b/contrib/minizip/compat/unzip.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/unzip.h> instead; in future releases #include <unzip.h> will stop working"
+#include <minizip/unzip.h>

--- a/contrib/minizip/compat/zip.h
+++ b/contrib/minizip/compat/zip.h
@@ -1,0 +1,2 @@
+#warning "please include <minizip/zip.h> instead; in future releases #include <zip.h> will stop working"
+#include <minizip/zip.h>

--- a/contrib/minizip/minizip.pc.in
+++ b/contrib/minizip/minizip.pc.in
@@ -10,4 +10,4 @@ Version: @PACKAGE_VERSION@
 License: Zlib
 Libs: -L${libdir} -lminizip
 Libs.private: -lz
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/minizip/compat

--- a/contrib/minizip/minizip.pc.txt
+++ b/contrib/minizip/minizip.pc.txt
@@ -10,4 +10,4 @@ Version: @minizip_VERSION@
 
 Requires:
 Libs: -L${libdir} -L${sharedlibdir} -lz -lminizip
-Cflags: -I${includedir}
+Cflags: -I${includedir} -I${includedir}/minizip/compat


### PR DESCRIPTION
the v1.3.2 release includes 7e6f0784cc0c33e8d5fcb368248168c6656f73c8. as the commit itself notes this breaks users of minizip, which have to update their includes. it's therefore (IMO) hard to see that as anything other than a breaking change, and it was released (1) in a patch version, (2) that also had security fixes, (3) without mentioning it in release notes. I'm pretty sure distros would appreciate if this were avoided in the future ^^'

the way this change was made, *there is no transitional period* where both includes work, to give users time to migrate to the new ones. this patch adds transitional headers in `$prefix/include/minizip/compat`, and also adds `$prefix/include/minizip/compat` to the cpp path. therefore, old includes like `#include <zip.h>` will include the compat header, which will emit a warning directing users to include the new one, and do so.

```
root@2ec567c66cdc:~# cat test.c 
#include <zip.h>
#include <stdio.h>

int main() { puts(zip_copyright); return 0; }
root@2ec567c66cdc:~# gcc $(pkg-config --cflags minizip) test.c $(pkg-config --libs minizip) -o test
In file included from test.c:1:
/usr/local/include/minizip/compat/zip.h:1:2: warning: #warning "please include <minizip/zip.h> instead; in future releases #include <zip.h> will stop working" [-Wcpp]
    1 | #warning "please include <minizip/zip.h> instead; in future releases #include <zip.h> will stop working"
      |  ^~~~~~~
root@2ec567c66cdc:~# ./test
 zip 1.01 Copyright 1998-2004 Gilles Vollant - https://www.winimage.com/zLibDll/minizip.html
```

this still breaks under `-Werror` even there it at least provides a clear error message.

furthermore, CMake is still using the old (un-namespaced) includes. so even if minizip users were okay with dropping support for v1.3.1 and older *today*, it would only work if minizip was built with autotools.

even more concerning is the fact that CMakeLists.txt places the headers **directly in `$prefix/include`**. this is worse than what autotools was initially doing (placing them in `$prefix/include/minizip` and placing that directory in the preprocessor path) because it guarantees conflict with libzip at the filesystem level. it prevents both libraries from being installed at the same time, not just used together in a program. I've made CMakeLists.txt mirror the autotools behavior.

also, despite there being a `minizip.pc` template for CMake, it's currently unused. I've fixed this too.

in a future major version, the compat headers can be dropped by reverting 11d5e2f1fc12efa0b5db0c8a22859770f5d2f2b8 and the transition will be complete.