### PR TITLE
Check extra field length accounts for ZIP64 info

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1335,8 +1335,9 @@ extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char* filename, c
         return ZIP_PARAMERROR;
     /* The extra field length must fit in 16 bits. If the member also requires
     // a Zip64 extra block, that will also need to fit within that 16-bit
-    // length, but that will be checked for later. */
-    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff))
+    // length. */
+    if ((size_extrafield_local>0xffff) || (size_extrafield_global>0xffff) ||
+        (zip64 && size_extrafield_local > 0xffff - 20))
         return ZIP_PARAMERROR;
 
     zi = (zip64_internal*)file;


### PR DESCRIPTION
The guard at zipOpenNewFileInZip4_64 checks that size_extrafield_local fits in 16 bits, but does not account for the 20-byte ZIP64 extended info block appended by `Write_LocalFileHeader` when zip64=1. 
Values in [65516, 65535] pass the guard but overflow the 2-byte header field after adding 20, producing a malformed ZIP where readers misposition the file data start. Reject these values when zip64 is set. 

This is a remaining ZIP64 edge case related CVE-2023-45853 fix I think