### PR TITLE
Add missing libs to miniunzip linker command.

### DIFF
--- a/contrib/minizip/Makefile.am
+++ b/contrib/minizip/Makefile.am
@@ -40,7 +40,7 @@ pkgconfig_DATA = minizip.pc
 EXTRA_PROGRAMS = miniunzip minizip
 
 miniunzip_SOURCES = miniunz.c
-miniunzip_LDADD = libminizip.la
+miniunzip_LDADD = libminizip.la -lz
 
 minizip_SOURCES = minizip.c
 minizip_LDADD = libminizip.la -lz


### PR DESCRIPTION
This is a variant of 81015585d278 ("Add missing libs to minizip linker command.") applying to miniunzip instead of minizip.

When linking these tools dynamically, the -L flag is searched for explicitly given libraries. The -lz is transitive via libminizip.la and hence the linker does not search the earlier -L$(zlib_top_builddir).

This tends to not fail on native builds, because very few native builds lack a system libz.so.1, but that system copy is the one being used here.

Another way to make this work would be influencing the searching of those libraries via -Wl,--rpath-link=$(zlib_top_builddir), but the explicit linking is already being used for minizip and less fragile.