### PR TITLE
Avoid undefined behavior of NULL pointer arithmetic in gz_vacate().

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -41,7 +41,7 @@ local int gz_init(gz_statep state) {
             gz_error(state, Z_MEM_ERROR, "out of memory");
             return -1;
         }
-        strm->next_in = NULL;
+        strm->next_in = state->in;
     }
 
     /* mark state as initialized */


### PR DESCRIPTION
Fix https://github.com/madler/zlib/issues/1214:
gz_init() set strm->next_in to NULL after deflateInit2(). On the first gzprintf() call, gz_vacate() then evaluated NULL + 0 at line 386, which is undefined behavior per C11 6.5.6p8. Initialize strm->next_in to state->in instead, so gz_vacate() always operates on a valid pointer.