### PR TITLE
bificurate static and dynamic libraries builds, to you can optionally only build one

### DIFF
--- a/zlibConfig.cmake.in
+++ b/zlibConfig.cmake.in
@@ -27,27 +27,6 @@ endif(ZLIB_FIND_COMPONENTS)
 
 # Compatibility: if only static was built, expose ZLIB::ZLIB and legacy vars.
 if(TARGET ZLIB::ZLIBSTATIC AND NOT TARGET ZLIB::ZLIB)
-    add_library(ZLIB::ZLIB INTERFACE IMPORTED)
-    set_property(TARGET ZLIB::ZLIB PROPERTY INTERFACE_LINK_LIBRARIES ZLIB::ZLIBSTATIC)
-
-    get_target_property(_zlib_include_dirs ZLIB::ZLIBSTATIC INTERFACE_INCLUDE_DIRECTORIES)
-    if(_zlib_include_dirs)
-        set_property(TARGET ZLIB::ZLIB PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_zlib_include_dirs}")
-    endif()
+    add_library(ZLIB::ZLIB ALIAS ZLIB::ZLIBSTATIC)
 endif()
 
-if(NOT DEFINED ZLIB_INCLUDE_DIRS AND TARGET ZLIB::ZLIB)
-    get_target_property(ZLIB_INCLUDE_DIRS ZLIB::ZLIB INTERFACE_INCLUDE_DIRECTORIES)
-endif()
-
-if(NOT DEFINED ZLIB_INCLUDE_DIR AND ZLIB_INCLUDE_DIRS)
-    list(GET ZLIB_INCLUDE_DIRS 0 ZLIB_INCLUDE_DIR)
-endif()
-
-if(NOT DEFINED ZLIB_LIBRARIES)
-    if(TARGET ZLIB::ZLIB)
-        set(ZLIB_LIBRARIES ZLIB::ZLIB)
-    elseif(TARGET ZLIB::ZLIBSTATIC)
-        set(ZLIB_LIBRARIES ZLIB::ZLIBSTATIC)
-    endif()
-endif()

--- a/zlibConfig.cmake.in
+++ b/zlibConfig.cmake.in
@@ -1,6 +1,14 @@
 @PACKAGE_INIT@
 
-set(_ZLIB_supported_components "shared" "static")
+set(_ZLIB_supported_components "")
+
+if(@ZLIB_BUILD_SHARED@)
+    list(APPEND _ZLIB_supported_components shared)
+endif(@ZLIB_BUILD_SHARED@)
+
+if(@ZLIB_BUILD_STATIC@)
+    list(APPEND _ZLIB_supported_components static)
+endif(@ZLIB_BUILD_STATIC@)
 
 if(ZLIB_FIND_COMPONENTS)
     foreach(_comp ${ZLIB_FIND_COMPONENTS})
@@ -16,3 +24,30 @@ else(ZLIB_FIND_COMPONENTS)
         include("${CMAKE_CURRENT_LIST_DIR}/ZLIB-${_component_config}.cmake")
     endforeach(_component_config IN LISTS _ZLIB_supported_components)
 endif(ZLIB_FIND_COMPONENTS)
+
+# Compatibility: if only static was built, expose ZLIB::ZLIB and legacy vars.
+if(TARGET ZLIB::ZLIBSTATIC AND NOT TARGET ZLIB::ZLIB)
+    add_library(ZLIB::ZLIB INTERFACE IMPORTED)
+    set_property(TARGET ZLIB::ZLIB PROPERTY INTERFACE_LINK_LIBRARIES ZLIB::ZLIBSTATIC)
+
+    get_target_property(_zlib_include_dirs ZLIB::ZLIBSTATIC INTERFACE_INCLUDE_DIRECTORIES)
+    if(_zlib_include_dirs)
+        set_property(TARGET ZLIB::ZLIB PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_zlib_include_dirs}")
+    endif()
+endif()
+
+if(NOT DEFINED ZLIB_INCLUDE_DIRS AND TARGET ZLIB::ZLIB)
+    get_target_property(ZLIB_INCLUDE_DIRS ZLIB::ZLIB INTERFACE_INCLUDE_DIRECTORIES)
+endif()
+
+if(NOT DEFINED ZLIB_INCLUDE_DIR AND ZLIB_INCLUDE_DIRS)
+    list(GET ZLIB_INCLUDE_DIRS 0 ZLIB_INCLUDE_DIR)
+endif()
+
+if(NOT DEFINED ZLIB_LIBRARIES)
+    if(TARGET ZLIB::ZLIB)
+        set(ZLIB_LIBRARIES ZLIB::ZLIB)
+    elseif(TARGET ZLIB::ZLIBSTATIC)
+        set(ZLIB_LIBRARIES ZLIB::ZLIBSTATIC)
+    endif()
+endif()


### PR DESCRIPTION
Not sure why this was removed before, why must you demand that both libraries be built, this can default, but why remove the ability to configure it?