### PR TITLE
fix: prevent signed integer overflow in gzseek64 for SEEK_SET

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -385,9 +385,11 @@ z_off64_t ZEXPORT gzseek64(gzFile file, z_off64_t offset, int whence) {
         return -1;
 
     /* normalize offset to a SEEK_CUR specification */
-    if (whence == SEEK_SET)
+    if (whence == SEEK_SET) {
+        if (offset < 0)
+            return -1;
         offset -= state->x.pos;
-    else {
+    } else {
         offset += state->past ? 0 : state->skip;
         state->skip = 0;
     }


### PR DESCRIPTION
## Summary

Fixes #1222. Generally agree with the issue's suggested fix, and I independently verified the patch's validity.

`gzseek64()` unconditionally subtracts `state->x.pos` from the user-supplied offset when `whence == SEEK_SET`. If `offset` is `INT64_MIN` and the stream position is non-zero, this overflows the signed `z_off64_t` type — undefined behavior flagged by UBSan.

Since a negative absolute position is always invalid for `SEEK_SET`, this patch rejects it early (returns `-1`) before the subtraction, eliminating the overflow without changing observable semantics.

## Fix

Add `if (offset < 0) return -1;` guard inside the `SEEK_SET` branch, before `offset -= state->x.pos`.

## Verification

Tested with UBSan-instrumented build:
- **Before**: `gzlib.c:389:16: runtime error: signed integer overflow: -9223372036854775808 - 1 cannot be represented in type 'off64_t'`
- **After**: No UBSan findings; clean exit

Reproducer:
```c
gzFile gz = gzopen("any_file", "rb");
char buf[2]; gzread(gz, buf, 2);  // advance pos to 1
gzseek(gz, LONG_MIN, SEEK_SET);   // triggers overflow without fix
gzclose(gz);
```