### PR TITLE
Fix configure for s390x CFLAGS, SFLAGS missing VGFMAFLAG

### DIFF
--- a/configure
+++ b/configure
@@ -969,8 +969,8 @@ EOF
 
     # prepare compiling for s390x
     if test $HAVE_S390X_VX -eq 1; then
-        CFLAGS="$CFLAGS -DHAVE_S390X_VX"
-        SFLAGS="$SFLAGS -DHAVE_S390X_VX"
+        CFLAGS="$CFLAGS -DHAVE_S390X_VX $VGFMAFLAG"
+        SFLAGS="$SFLAGS -DHAVE_S390X_VX $VGFMAFLAG"
         OBJC="$OBJC crc32_vx.o"
         PIC_OBJC="$PIC_OBJC crc32_vx.lo"
     else


### PR DESCRIPTION
I ran into this issue when trying to build zlib for s390x and the AI suggested this fix. I checked it and the fix looks sound to me but I don't know the whole configure script. Here's the excerpt from the failed build to give you an idea:

```
...
#20 2.670 + ./configure --static
#20 2.684 Using s390x-linux-gnu-ar
#20 2.688 Using s390x-linux-gnu-ranlib
#20 2.692 Using s390x-linux-gnu-nm
#20 2.761 Building static library libz.a version 1.3.2 with s390x-linux-gnu-gcc.
#20 2.785 Checking for size_t... Yes.
#20 2.802 Checking for off64_t... Yes.
#20 2.803 Checking for fseeko... Yes.
#20 2.846 Checking for strerror... Yes.
#20 2.876 Checking for unistd.h... Yes.
#20 2.897 Checking for stdarg.h... Yes.
#20 2.929 Checking whether to use vs[n]printf() or s[n]printf()... using vs[n]printf().
#20 2.981 Checking for vsnprintf() in stdio.h... Yes.
#20 3.007 Checking for return value of vsnprintf()... Yes.
#20 3.024 Checking for attribute(visibility) support... Yes.
#20 3.036 Checking for s390x build ... Yes.
#20 3.067 Checking for s390x vx vector extension (march=z13) ... Yes.
#20 3.078 ++ nproc
#20 3.079 + make -j4
#20 3.082 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX -I. -c -o example.o test/example.c
#20 3.083 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o adler32.o adler32.c
#20 3.084 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o crc32.o crc32.c
#20 3.086 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o deflate.o deflate.c
#20 3.374 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o infback.o infback.c
#20 3.411 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o inffast.o inffast.c
#20 3.628 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o inflate.o inflate.c
#20 3.850 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o inftrees.o inftrees.c
#20 4.128 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o trees.o trees.c
#20 4.245 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o zutil.o zutil.c
#20 4.295 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o compress.o compress.c
#20 4.351 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o uncompr.o uncompr.c
#20 4.453 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o gzclose.o gzclose.c
#20 4.577 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o gzlib.o gzlib.c
#20 5.230 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o gzread.o gzread.c
#20 5.455 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX  -c -o gzwrite.o gzwrite.c
#20 5.766 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX   -c -o crc32_vx.o contrib/crc32vx/crc32_vx.c
#20 5.794 s390x-linux-gnu-gcc -O3 -fPIC -D_LARGEFILE64_SOURCE=1 -DHAVE_HIDDEN -DHAVE_S390X_VX -I. -c -o minigzip.o test/minigzip.c
#20 5.843 In file included from contrib/crc32vx/crc32_vx.c:20:
#20 5.843 contrib/crc32vx/crc32_vx.c: In function 'crc32_le_vgfm_16':
#20 5.844 contrib/crc32vx/crc32_vx.c:79:17: error: '__builtin_s390_vec_insert' requires '-mvx'
#20 5.844    79 |     v0 = (uv2di)vec_insert(crc, (uv4si)v0, 3);
#20 5.844       |                 ^~~~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:82:16: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    82 |     uv2di v1 = vec_perm(((uv2di *)buf)[0], ((uv2di *)buf)[0], perm_le2be);
#20 5.845       |                ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:83:16: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    83 |     uv2di v2 = vec_perm(((uv2di *)buf)[1], ((uv2di *)buf)[1], perm_le2be);
#20 5.845       |                ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:84:16: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    84 |     uv2di v3 = vec_perm(((uv2di *)buf)[2], ((uv2di *)buf)[2], perm_le2be);
#20 5.845       |                ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:85:16: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    85 |     uv2di v4 = vec_perm(((uv2di *)buf)[3], ((uv2di *)buf)[3], perm_le2be);
#20 5.845       |                ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:93:24: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    93 |         uv16qi part1 = vec_perm(((uv16qi *)buf)[0], ((uv16qi *)buf)[0], perm_le2be);
#20 5.845       |                        ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:94:24: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    94 |         uv16qi part2 = vec_perm(((uv16qi *)buf)[1], ((uv16qi *)buf)[1], perm_le2be);
#20 5.845       |                        ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:95:24: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    95 |         uv16qi part3 = vec_perm(((uv16qi *)buf)[2], ((uv16qi *)buf)[2], perm_le2be);
#20 5.845       |                        ^~~~~~~~
#20 5.845 contrib/crc32vx/crc32_vx.c:96:24: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.845    96 |         uv16qi part4 = vec_perm(((uv16qi *)buf)[3], ((uv16qi *)buf)[3], perm_le2be);
#20 5.845       |                        ^~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:125:14: error: '__builtin_s390_vec_perm' requires '-mvx'
#20 5.846   125 |         v2 = vec_perm(*(uv2di *)buf, *(uv2di *)buf, perm_le2be);
#20 5.846       |              ^~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:141:10: error: '__builtin_s390_vec_insert' requires '-mvx'
#20 5.846   141 |     v9 = vec_insert((unsigned char)0x40, v9, 7);
#20 5.846       |          ^~~~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:148:10: error: '__builtin_s390_vec_srb' requires '-mvx'
#20 5.846   148 |     v0 = vec_srb(r4r3, (uv2di)v9);
#20 5.846       |          ^~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:172:10: error: '__builtin_s390_vec_insert' requires '-mvx'
#20 5.846   172 |     v9 = vec_insert((unsigned char)0x20, v9, 7);
#20 5.846       |          ^~~~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:173:10: error: '__builtin_s390_vec_srb' requires '-mvx'
#20 5.846   173 |     v2 = vec_srb(v1, (uv2di)v9);
#20 5.846       |          ^~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:174:10: error: '__builtin_s390_vec_unpackl' requires '-mvx'
#20 5.846   174 |     v1 = vec_unpackl((uv4si)v1);  /* Split rightmost doubleword */
#20 5.846       |          ^~~~~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:197:10: error: '__builtin_s390_vec_unpackl' requires '-mvx'
#20 5.846   197 |     v2 = vec_unpackl((uv4si)v1);
#20 5.846       |          ^~~~~~~~~~~
#20 5.846 contrib/crc32vx/crc32_vx.c:205:10: error: '__builtin_s390_vec_unpackl' requires '-mvx'
#20 5.846   205 |     v2 = vec_unpackl((uv4si)v2);
#20 5.846       |          ^~~~~~~~~~~
#20 5.852 make: *** [Makefile:165: crc32_vx.o] Error 1
#20 5.855 make: *** Waiting for unfinished jobs....
#20 ERROR: process "/bin/sh -c /zlib.sh" did not complete successfully: exit code: 2
```