### PR TITLE
[CVE-2026-4738] infback9: Remove offset pointer optimization in inftrees.c.

### DIFF
--- a/contrib/infback9/inftree9.c
+++ b/contrib/infback9/inftree9.c
@@ -49,7 +49,7 @@ int inflate_table9(codetype type, unsigned short FAR *lens, unsigned codes,
     code FAR *next;             /* next available space in table */
     const unsigned short FAR *base;     /* base value table to use */
     const unsigned short FAR *extra;    /* extra bits table to use */
-    int end;                    /* use base and extra for symbol > end */
+    unsigned match;             /* use base and extra for symbol >= match */
     unsigned short count[MAXBITS+1];    /* number of codes of each length */
     unsigned short offs[MAXBITS+1];     /* offsets in table for each length */
     static const unsigned short lbase[31] = { /* Length codes 257..285 base */
@@ -170,19 +170,17 @@ int inflate_table9(codetype type, unsigned short FAR *lens, unsigned codes,
     switch (type) {
     case CODES:
         base = extra = work;    /* dummy value--not used */
-        end = 19;
+        match = 20;
         break;
     case LENS:
         base = lbase;
-        base -= 257;
         extra = lext;
-        extra -= 257;
-        end = 256;
+        match = 257;
         break;
     default:            /* DISTS */
         base = dbase;
         extra = dext;
-        end = -1;
+        match = 0;
     }
 
     /* initialize state for loop */
@@ -205,13 +203,13 @@ int inflate_table9(codetype type, unsigned short FAR *lens, unsigned codes,
     for (;;) {
         /* create table entry */
         this.bits = (unsigned char)(len - drop);
-        if ((int)(work[sym]) < end) {
+        if ((unsigned)(work[sym]) + 1 < match) {
             this.op = (unsigned char)0;
             this.val = work[sym];
         }
-        else if ((int)(work[sym]) > end) {
-            this.op = (unsigned char)(extra[work[sym]]);
-            this.val = base[work[sym]];
+        else if ((work[sym]) >= match) {
+            this.op = (unsigned char)(extra[work[sym]- match]);
+            this.val = base[work[sym]- match];
         }
         else {
             this.op = (unsigned char)(32 + 64);         /* end of block */


### PR DESCRIPTION
This PR addresses [CVE-2026-4738](https://nvd.nist.gov/vuln/detail/CVE-2026-4738) which appears to have been patched in a downstream repository, but it doesn't look like it was submitted to the upstream zlib repository.

I'm not knowledgeable on the specifics of this exploit, but I thought I'd offer it in case this fix simply fell through the cracks.

As noted in the [downstream PR](https://github.com/OSGeo/gdal/pull/12244) this is basically the fix for [CVE-2016-9840](https://nvd.nist.gov/vuln/detail/CVE-2016-9840) being applied to infback9.