### PR TITLE
Install minizip.pc from CMake

### DIFF
--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -62,8 +62,10 @@ if(NOT DEFINED ZLIB_BUILD_MINIZIP)
     find_package(ZLIB REQUIRED COMPONENTS ${REQUIRED_COMPONENTS} CONFIG)
 endif(NOT DEFINED ZLIB_BUILD_MINIZIP)
 
+set(MINIZIP_REQUIRES_PRIVATE "")
 if(MINIZIP_ENABLE_BZIP2)
     find_package(BZip2 REQUIRED)
+    string(APPEND MINIZIP_REQUIRES_PRIVATE " bzip2")
 endif(MINIZIP_ENABLE_BZIP2)
 
 #
@@ -274,6 +276,18 @@ if(MINIZIP_INSTALL)
         FILES ${LIBMINIZIP_HDRS}
         COMPONENT Development
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+
+    set(prefix "${CMAKE_INSTALL_PREFIX}")
+    set(exec_prefix "\${prefix}")
+    set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+    set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    set(PACKAGE_VERSION "${minizip_VERSION}")
+    configure_file(
+        ${minizip_SOURCE_DIR}/minizip.pc.in
+        ${minizip_BINARY_DIR}/minizip.pc)
+    install(
+        FILES ${minizip_BINARY_DIR}/minizip.pc
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 endif(MINIZIP_INSTALL)
 
 if(MINIZIP_BUILD_TESTING)

--- a/contrib/minizip/configure.ac
+++ b/contrib/minizip/configure.ac
@@ -26,6 +26,7 @@ esac
 AM_CONDITIONAL([WIN32], [test "${WIN32}" = "yes"])
 
 
+AC_SUBST(MINIZIP_REQUIRES_PRIVATE, [])
 AC_SUBST([HAVE_UNISTD_H], [0])
 AC_CHECK_HEADER([unistd.h], [HAVE_UNISTD_H=1], [])
 AC_CONFIG_FILES([Makefile minizip.pc])

--- a/contrib/minizip/minizip.pc.in
+++ b/contrib/minizip/minizip.pc.in
@@ -5,9 +5,8 @@ includedir=@includedir@
 
 Name: minizip
 Description: Minizip zip file manipulation library
-Requires:
 Version: @PACKAGE_VERSION@
 License: Zlib
+Requires.private: zlib @MINIZIP_REQUIRES_PRIVATE@
 Libs: -L${libdir} -lminizip
-Libs.private: -lz
 Cflags: -I${includedir}


### PR DESCRIPTION
Install the minizip.pc file when building with CMake.
Resolve the zlib link dependency with `Requires:` so that finding the actual link lib can be left to pkg-config at the time lib minizip is used. This can also handle library name suffixes like `s` and `d` when they are exposed via zlib.pc.
Add the bzip2 link dependency when needed. (This is not used by autotools AFAICS.)

Upstreamed from the ongoing 1.3.2 update of the vcpkg port of minizip.