### PR TITLE
Add iowin32.c to libminizip sources

### DIFF
--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -107,9 +107,9 @@ check_c_source_compiles(
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-set(LIBMINIZIP_SRCS ioapi.c mztools.c unzip.c zip.c)
+set(LIBMINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> mztools.c unzip.c zip.c)
 
-set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h mztools.h unzip.h zip.h)
+set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${WIN32}>:iowin32.h> mztools.h unzip.h zip.h)
 
 set(MINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> minizip.c zip.c)
 

--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -111,22 +111,13 @@ set(LIBMINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> mztools.c unzip.c zip.
 
 set(LIBMINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${WIN32}>:iowin32.h> mztools.h unzip.h zip.h)
 
-set(MINIZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> minizip.c zip.c)
+set(MINIZIP_SRCS minizip.c)
 
-set(MINIZIP_HDRS crypt.h ints.h ioapi.h $<$<BOOL:${WIN32}>:iowin32.h> skipset.h
-                 zip.h)
+set(MINIZIP_HDRS skipset.h)
 
-set(MINIUNZIP_SRCS ioapi.c $<$<BOOL:${WIN32}>:iowin32.c> miniunz.c unzip.c
-                   zip.c)
+set(MINIUNZIP_SRCS miniunz.c)
 
-set(MINIUNZIP_HDRS
-    crypt.h
-    ints.h
-    ioapi.h
-    $<$<BOOL:${WIN32}>:iowin32.h>
-    skipset.h
-    unzip.h
-    zip.h)
+set(MINIUNZIP_HDRS skipset.h)
 
 if(WIN32 OR CYGWIN)
     set(minizip_static_suffix "s")


### PR DESCRIPTION
Some package uses vendored copies of minizip and call iowin32 API. (Known from vcpkg: collada-dom, fmilib, libxlsxwriter.)
The vcpkg registry needs to devendor such copies, and in that way needs iowin32 in libminizip.

Remarks:
- If accepted, a similar change might be wanted for zlib1-dll.
- IMHO the sources and headers of LIBMINIZIP should not appear again in the sources and headers of MINIZIP and MINIUNZIP. Both executable link LIBMINIZIP.
  **Update:** This added now.