### PR TITLE
fix: add bounds check on Huffman code lengths in inflate_table9()

### DIFF
--- a/contrib/infback9/inftree9.c
+++ b/contrib/infback9/inftree9.c
@@ -100,11 +100,13 @@ int inflate_table9(codetype type, unsigned short FAR *lens, unsigned codes,
        decoding tables.
      */
 
-    /* accumulate lengths for codes (assumes lens[] all in 0..MAXBITS) */
+    /* validate and accumulate lengths for codes */
     for (len = 0; len <= MAXBITS; len++)
         count[len] = 0;
-    for (sym = 0; sym < codes; sym++)
+    for (sym = 0; sym < codes; sym++) {
+        if (lens[sym] > MAXBITS) return -1;     /* invalid code length */
         count[lens[sym]]++;
+    }
 
     /* bound code lengths, force root to be within code lengths */
     root = *bits;


### PR DESCRIPTION
Fixes #1239

## Summary

`inflate_table9()` in `contrib/infback9/inftree9.c` uses values from the `lens[]` array as indices into `count[]` without bounds checking. The comment on line 103 explicitly states *"assumes lens[] all in 0..MAXBITS"* but this assumption is never enforced.

When called with `lens[sym] > MAXBITS` (15), the code accesses `count[lens[sym]]` out of bounds, since `count` is only `MAXBITS+1` (16) elements. This can corrupt adjacent stack memory when processing crafted deflate64 compressed data.

## Root Cause

The equivalent function `inflate_table()` in `inftrees.c` (main zlib) already validates code lengths and returns an error for invalid values. The `contrib/infback9` variant was never given the same safety check.

## Fix

Add a bounds check that returns `-1` (error) if any `lens[sym] > MAXBITS`, consistent with the validation in `inftrees.c`.

```diff
-    /* accumulate lengths for codes (assumes lens[] all in 0..MAXBITS) */
+    /* validate and accumulate lengths for codes */
     for (len = 0; len <= MAXBITS; len++)
         count[len] = 0;
-    for (sym = 0; sym < codes; sym++)
-        count[lens[sym]]++;
+    for (sym = 0; sym < codes; sym++) {
+        if (lens[sym] > MAXBITS) return -1;     /* invalid code length */
+        count[lens[sym]]++;
+    }
```
