### PR TITLE
Fix signed integer overflow in gzseek64 SEEK_SET normalization (UBSan)

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -385,8 +385,18 @@ z_off64_t ZEXPORT gzseek64(gzFile file, z_off64_t offset, int whence) {
         return -1;
 
     /* normalize offset to a SEEK_CUR specification */
-    if (whence == SEEK_SET)
+    if (whence == SEEK_SET) {
+        /* Guard against signed integer overflow when normalising SEEK_SET offset:
+         * (offset - state->x.pos) overflows when offset < INT64_MIN + pos.
+         * File position is always >= 0, so INT64_MIN + pos cannot itself
+         * underflow.  Use INT64_MIN from <limits.h> (included via gzguts.h)
+         * rather than a raw literal for portability and readability. */
+        if (offset < (z_off64_t)INT64_MIN + state->x.pos) {
+            gz_error(state, Z_STREAM_ERROR, "invalid offset");
+            return -1;
+        }
         offset -= state->x.pos;
+    }
     else {
         offset += state->past ? 0 : state->skip;
         state->skip = 0;


### PR DESCRIPTION
## Summary

Fix a signed integer overflow (undefined behavior) in `gzseek64()` when normalizing a `SEEK_SET` offset.

## Root Cause

`gzlib.c` line 389:
```c
if (whence == SEEK_SET)
    offset -= state->x.pos;  /* UB when offset == INT64_MIN and pos > 0 */
```

`offset` and `state->x.pos` are both `z_off64_t` (signed 64-bit). When the caller passes `offset == INT64_MIN` (-9223372036854775808) and the stream has advanced at least one byte (`state->x.pos > 0`), the subtraction overflows the signed type — undefined behavior per C11 §6.5p5, and flagged by UBSan as `runtime error: signed integer overflow`.

The intended error path (checking `offset < 0` after normalization) is never reached because the overflow wraps to a large positive value, bypassing the bounds check entirely.

## Fix

Add an explicit overflow guard before the subtraction:

```c
if (offset < (z_off64_t)(-9223372036854775807LL - 1) + state->x.pos) {
    gz_error(state, Z_STREAM_ERROR, "invalid offset");
    return -1;
}
offset -= state->x.pos;
```

This preserves all existing semantics for valid offsets and turns the UB into a clean error return.

Fixes #1222.