### PR TITLE
CMake: Don't use a linker version script on OHOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ if(ZLIB_BUILD_SHARED)
     if(UNIX
         AND NOT APPLE
         AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX)
+        AND NOT (CMAKE_SYSTEM_NAME STREQUAL OHOS)
         AND NOT (CMAKE_SYSTEM_NAME STREQUAL SunOS))
         # On unix-like platforms the library is almost always called libz
         set_target_properties(
@@ -207,6 +208,7 @@ if(ZLIB_BUILD_SHARED)
         UNIX
         AND NOT APPLE
         AND NOT (CMAKE_SYSTEM_NAME STREQUAL AIX)
+        AND NOT (CMAKE_SYSTEM_NAME STREQUAL OHOS)
         AND NOT (CMAKE_SYSTEM_NAME STREQUAL SunOS))
 endif(ZLIB_BUILD_SHARED)
 


### PR DESCRIPTION
Don't use a linker version script on HarmonyOS / OpenHarmony. These platforms don't support symbol versioning. Both platforms have the CMAKE_SYSTEM_NAME OHOS.