### PR TITLE
Control linking of BZip2 by input variable

### DIFF
--- a/contrib/minizip/CMakeLists.txt
+++ b/contrib/minizip/CMakeLists.txt
@@ -146,7 +146,7 @@ if(MINIZIP_BUILD_SHARED)
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>
                 $<$<BOOL:${HAVE_UNISTD_H}>:HAVE_UNISTD_H=1>
         PUBLIC $<$<BOOL:${HAVE_OFF64_T}>:_LARGEFILE64_SOURCE=1>
-                $<$<BOOL:${BZIP2_FOUND}>:HAVE_BZIP2=1>
+                $<$<BOOL:${MINIZIP_ENABLE_BZIP2}>:HAVE_BZIP2=1>
                 $<$<BOOL:NOT:${HAVE_FOPEN64}>:USE_FILE32API=1>)
 
     if(NOT CYGWIN)
@@ -163,7 +163,7 @@ if(MINIZIP_BUILD_SHARED)
 
     target_link_libraries(libminizip
         PUBLIC ZLIB::ZLIB
-            $<$<BOOL:${BZIP2_FOUND}>:BZip2::BZip2>)
+            $<$<BOOL:${MINIZIP_ENABLE_BZIP2}>:BZip2::BZip2>)
 
     add_executable(minizip ${MINIZIP_SRCS} ${MINIZIP_HDRS})
     set_target_properties(minizip PROPERTIES EXPORT_NAME minizip_executable)
@@ -190,7 +190,7 @@ if(MINIZIP_BUILD_STATIC)
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>
                 $<$<BOOL:${HAVE_UNISTD_H}>:HAVE_UNISTD_H=1>
         PUBLIC $<$<BOOL:${HAVE_OFF64_T}>:_LARGEFILE64_SOURCE=1>
-                $<$<BOOL:${BZIP2_FOUND}>:HAVE_BZIP2=1>
+                $<$<BOOL:${MINIZIP_ENABLE_BZIP2}>:HAVE_BZIP2=1>
                 $<$<BOOL:NOT:${HAVE_FOPEN64}>:USE_FILE32API=1>)
     set_target_properties(
         libminizipstatic PROPERTIES EXPORT_NAME minizipstatic
@@ -201,7 +201,7 @@ if(MINIZIP_BUILD_STATIC)
     endif(CYGWIN)
 
     target_link_libraries(libminizipstatic PUBLIC ZLIB::ZLIBSTATIC
-        $<$<BOOL:${BZIP2_FOUND}>:BZip2::BZip2>)
+        $<$<BOOL:${MINIZIP_ENABLE_BZIP2}>:BZip2::BZip2>)
 
     add_executable(minizipstatic ${MINIZIP_SRCS} ${MINIZIP_HDRS})
     set_target_properties(minizipstatic PROPERTIES EXPORT_NAME


### PR DESCRIPTION
`BZip2::BZip2` shall be used iff option `MINIZIP_ENABLE_BZIP2` is enabled. This change 
- avoids unexpected linking when zlib is built as a subproject of another project which uses `BZip2`,
- replaces the use of the `BZIP2_FOUND` variable (EDIT: deprecated in CMake 4.3) which does not match the capitalization pattern of the `BZip2` package name with the existing `MINIZIP_ENABLE_BZIP2` option variable.
- in this way, applies the same variable which is used in `minizipConfig.cmake.in`.

The first point is a behavioral change, as normal for a bug fix.
