### PR TITLE
fix out-of-bounds access in zipRemoveExtraInfoBlock

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -2201,6 +2201,7 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
   char* pTmp;
   short header;
   short dataSize;
+  int blockSize;
 
   int retVal = ZIP_OK;
 
@@ -2210,21 +2211,25 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
   pNewHeader = (char*)ALLOC((unsigned)*dataLen);
   pTmp = pNewHeader;
 
-  while(p < (pData + *dataLen))
+  while(p + 4 <= pData + *dataLen)
   {
     header = *(short*)p;
     dataSize = *(((short*)p)+1);
+    blockSize = (int)(unsigned short)dataSize + 4;
+
+    if (blockSize > pData + *dataLen - p) /* truncated block, stop */
+      break;
 
     if( header == sHeader ) /* Header found. */
     {
-      p += dataSize + 4; /* skip it. do not copy to temp buffer */
+      p += blockSize; /* skip it. do not copy to temp buffer */
     }
     else
     {
       /* Extra Info block should not be removed, So copy it to the temp buffer. */
-      memcpy(pTmp, p, dataSize + 4);
-      p += dataSize + 4;
-      size += dataSize + 4;
+      memcpy(pTmp, p, blockSize);
+      p += blockSize;
+      size += blockSize;
     }
 
   }


### PR DESCRIPTION
zipRemoveExtraInfoBlock() reads a signed short dataSize from each extra-field block and uses dataSize+4 as both the memcpy length and the advance, without checking it against the remaining input. A crafted extra field (dataSize 0x7fff in a 4-byte field, or a negative value such as 0xffff) overruns the *dataLen-sized pNewHeader buffer and reads past pData. The block size belongs to attacker-controlled central-directory/local-header data, so the bound has to be enforced here. Read the size as unsigned and stop at any block that does not fit.