### PR TITLE
avoid signed left-shift overflow in mztools READ_32

### DIFF
--- a/contrib/minizip/mztools.c
+++ b/contrib/minizip/mztools.c
@@ -16,7 +16,7 @@
 
 #define READ_8(adr)  ((unsigned char)*(adr))
 #define READ_16(adr) ( READ_8(adr) | (READ_8(adr+1) << 8) )
-#define READ_32(adr) ( READ_16(adr) | (READ_16((adr)+2) << 16) )
+#define READ_32(adr) ( (unsigned)READ_16(adr) | ((unsigned)READ_16((adr)+2) << 16) )
 
 #define WRITE_8(buff, n) do { \
   *((unsigned char*)(buff)) = (unsigned char) ((n) & 0xff); \


### PR DESCRIPTION
READ_32 in mztools.c computes `READ_16((adr)+2) << 16`, where READ_16 has type int. When that 16-bit word is >= 0x8000 the shift pushes a set bit into the sign position, which is undefined behavior; unzRepair runs it on crc/size fields read straight from the input file, so almost any real archive trips it. UBSan reports "left shift of 32768 by 16 places cannot be represented in type 'int'". Cast the halves to unsigned before combining.