### PR TITLE
crc32_vx: fix build failure with musl on s390x

### DIFF
--- a/contrib/crc32vx/crc32_vx.c
+++ b/contrib/crc32vx/crc32_vx.c
@@ -20,6 +20,10 @@
 #include <vecintrin.h>
 #include <sys/auxv.h>
 
+#ifndef HWCAP_S390_VX
+#  define HWCAP_S390_VX (1UL << 11)
+#endif
+
 #ifdef __clang__
 #  if ((__clang_major__ == 18) || (__clang_major__ == 19 && (__clang_minor__ < 1 || (__clang_minor__ == 1 && __clang_patchlevel__ < 2))))
 # error crc32_vx optimizations are broken due to compiler bug in Clang versions: 18.0.0 <= clang_version < 19.1.2. \


### PR DESCRIPTION
On musl libc, the HWCAP_S390_VX constant is not defined in <sys/auxv.h>, unlike glibc which provides it. This leads to a compilation failure when cross-compiling for s390x with musl (discovered during Buildroot builds):

  contrib/crc32vx/crc32_vx.c: In function 's390_crc32_setup':
  crc32_vx.c:242:17: error: 'HWCAP_S390_VX' undeclared (first use
  in this function); did you mean 'HWCAP_S390_VXRS'?

Define HWCAP_S390_VX to its standard Linux ABI value of 2048 (1UL << 11) if it is not already provided by the system headers, allowing the build to succeed under musl libc.