### PR TITLE
gzguts: always include errno.h on non-Windows-CE platforms

### DIFF
--- a/gzguts.h
+++ b/gzguts.h
@@ -128,8 +128,8 @@
 #  include <windows.h>
 #  define zstrerror() gz_strwinerror((DWORD)GetLastError())
 #else
+#  include <errno.h>
 #  ifndef NO_STRERROR
-#    include <errno.h>
 #    define zstrerror() strerror(errno)
 #  else
 #    define zstrerror() "stdio error (consult errno)"


### PR DESCRIPTION
When NO_STRERROR is defined (e.g. under certain musl static configurations where strerror is detected as unavailable), gzguts.h does not include <errno.h>. However, gzread.c and gzwrite.c use errno, EAGAIN, and EWOULDBLOCK unconditionally, leading to compilation failures (discovered during Buildroot cross-compilation builds with musl):

  gzread.c: In function 'gz_load':
  gzread.c:24:5: error: 'errno' undeclared (first use in this
  function)
  gzread.c:36:22: error: 'EAGAIN' undeclared (first use in this
  function)

Move the #include <errno.h> outside the #ifndef NO_STRERROR guard so that errno and the error constants are always available, regardless of whether strerror() itself is present.