### PR TITLE
null-terminate truncated name and comment in minizip unzGetCurrentFileInfo

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -863,8 +863,12 @@ local int unz64local_GetCurrentFileInfoInternal(unzFile file,
             uSizeRead = fileNameBufferSize;
 
         if ((file_info.size_filename>0) && (fileNameBufferSize>0))
+        {
             if (ZREAD64(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
+            if (file_info.size_filename>=fileNameBufferSize)
+                *(szFileName+fileNameBufferSize-1)='\0';
+        }
         lSeek -= uSizeRead;
     }
 
@@ -981,8 +985,12 @@ local int unz64local_GetCurrentFileInfoInternal(unzFile file,
         }
 
         if ((file_info.size_file_comment>0) && (commentBufferSize>0))
+        {
             if (ZREAD64(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
+            if (file_info.size_file_comment>=commentBufferSize)
+                *(szComment+commentBufferSize-1)='\0';
+        }
         lSeek+=file_info.size_file_comment - uSizeRead;
     }
     else


### PR DESCRIPTION
Noticed unz64local_GetCurrentFileInfoInternal copies size_filename bytes from the zip central directory into the caller's buffer but never writes a terminator when the name is at least as long as the buffer. unzLocateFile then strcmp's that buffer, and any caller doing strlen on the returned name reads past it. A 300-byte filename into a 300-byte buffer gives strlen 316 here. The comment field has the same gap. Terminate the last byte in the truncating case for both.