### PR TITLE
check wcstombs failure in gz_open to avoid unterminated path

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -198,8 +198,15 @@ local gzFile gz_open(const void *path, int fd, const char *mode) {
 
     /* save the path name for error messages */
 #ifdef WIDECHAR
-    if (fd == -2)
+    if (fd == -2) {
         len = wcstombs(NULL, path, 0);
+        if (len == (z_size_t)-1) {
+            /* path has a character not representable as a multibyte sequence --
+               len + 1 would wrap to zero below, leaving an unterminated path */
+            free(state);
+            return NULL;
+        }
+    }
     else
 #endif
         len = strlen((const char *)path);


### PR DESCRIPTION
When gz_open is given a wide path (fd == -2), it sizes the multibyte copy with wcstombs(NULL, path, 0) but never checks the (size_t)-1 error return. If the path holds a character with no multibyte representation in the current locale, len becomes (size_t)-1, len + 1 wraps to zero, malloc(0) hands back a non-NULL empty block, and the following wcstombs writes nothing, so state->path is never terminated. gz_error later treats it as a C string and reads past the allocation. Bail out the same way as the malloc failure when wcstombs reports an error.