### PR TITLE
validate extra field records in zipRemoveExtraInfoBlock

### DIFF
--- a/contrib/minizip/test/CMakeLists.txt
+++ b/contrib/minizip/test/CMakeLists.txt
@@ -174,3 +174,11 @@ set_tests_properties(
 
 set_tests_properties(minizip_add_subdirectory_exclude_build
                      PROPERTIES FIXTURES_REQUIRED mzasx_config)
+
+add_executable(minizip_remove_extra_test remove_extra_test.c)
+if(MINIZIP_BUILD_STATIC)
+    target_link_libraries(minizip_remove_extra_test PRIVATE MINIZIP::minizipstatic)
+else(MINIZIP_BUILD_STATIC)
+    target_link_libraries(minizip_remove_extra_test PRIVATE MINIZIP::minizip)
+endif(MINIZIP_BUILD_STATIC)
+add_test(NAME minizip_remove_extra_test COMMAND minizip_remove_extra_test)

--- a/contrib/minizip/test/remove_extra_test.c
+++ b/contrib/minizip/test/remove_extra_test.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "zip.h"
+
+static int check(const char *name, int condition) {
+    if (!condition) {
+        fprintf(stderr, "failed: %s\n", name);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    char fields[] = {
+        1, 0, 2, 0, 'x', 'y',
+        2, 0, 1, 0, 'z'
+    };
+    char unaligned[] = {
+        0,
+        1, 0, 1, 0, 'x',
+        2, 0, 1, 0, 'y'
+    };
+    char truncated_header[] = {1, 0, 0, 0, 2};
+    char truncated_data[] = {1, 0, 2, 0, 'x'};
+    char original[sizeof(truncated_data)];
+    int len;
+    int ret = 0;
+
+    len = (int)sizeof(fields);
+    ret |= check("remove matching field",
+                 zipRemoveExtraInfoBlock(fields, &len, 1) == ZIP_OK);
+    ret |= check("preserve non-matching field",
+                 len == 5 && memcmp(fields, "\2\0\1\0z", 5) == 0);
+
+    len = (int)sizeof(unaligned) - 1;
+    ret |= check("accept unaligned input",
+                 zipRemoveExtraInfoBlock(unaligned + 1, &len, 1) == ZIP_OK);
+    ret |= check("preserve unaligned non-matching field",
+                 len == 5 && memcmp(unaligned + 1, "\2\0\1\0y", 5) == 0);
+
+    len = (int)sizeof(truncated_header);
+    ret |= check("reject truncated header",
+                 zipRemoveExtraInfoBlock(truncated_header, &len, 1) ==
+                     ZIP_PARAMERROR);
+
+    memcpy(original, truncated_data, sizeof(original));
+    len = (int)sizeof(truncated_data);
+    ret |= check("reject truncated payload",
+                 zipRemoveExtraInfoBlock(truncated_data, &len, 1) ==
+                     ZIP_PARAMERROR);
+    ret |= check("leave malformed input unchanged",
+                 len == (int)sizeof(truncated_data) &&
+                     memcmp(truncated_data, original, sizeof(original)) == 0);
+
+    return ret;
+}

--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -2199,8 +2199,9 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
   int size = 0;
   char* pNewHeader;
   char* pTmp;
-  short header;
-  short dataSize;
+  unsigned header;
+  unsigned dataSize;
+  unsigned remove = (unsigned short)sHeader;
 
   int retVal = ZIP_OK;
 
@@ -2208,14 +2209,29 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
     return ZIP_PARAMERROR;
 
   pNewHeader = (char*)ALLOC((unsigned)*dataLen);
+  if (pNewHeader == NULL)
+    return ZIP_INTERNALERROR;
   pTmp = pNewHeader;
 
   while(p < (pData + *dataLen))
   {
-    header = *(short*)p;
-    dataSize = *(((short*)p)+1);
+    int left = (int)((pData + *dataLen) - p);
 
-    if( header == sHeader ) /* Header found. */
+    if (left < 4) {
+      retVal = ZIP_PARAMERROR;
+      break;
+    }
+
+    header = (unsigned)(unsigned char)p[0] |
+             ((unsigned)(unsigned char)p[1] << 8);
+    dataSize = (unsigned)(unsigned char)p[2] |
+               ((unsigned)(unsigned char)p[3] << 8);
+    if (dataSize > (unsigned)left - 4) {
+      retVal = ZIP_PARAMERROR;
+      break;
+    }
+
+    if( header == remove ) /* Header found. */
     {
       p += dataSize + 4; /* skip it. do not copy to temp buffer */
     }
@@ -2229,7 +2245,7 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
 
   }
 
-  if(size < *dataLen)
+  if(retVal == ZIP_OK && size < *dataLen)
   {
     /* clean old extra info block. */
     memset(pData,0, *dataLen);
@@ -2243,7 +2259,7 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
 
     retVal = ZIP_OK;
   }
-  else
+  else if(retVal == ZIP_OK)
     retVal = ZIP_ERRNO;
 
   free(pNewHeader);


### PR DESCRIPTION
## Summary

Validate extra-field records while walking the buffer in `zipRemoveExtraInfoBlock()`.

### Changes

* Verify that at least 4 bytes remain before reading an extra-field header.
* Verify that the declared payload length fits within the remaining buffer before advancing or copying.
* Decode header and size fields byte-wise instead of using unaligned `short*` accesses.
* Return `ZIP_PARAMERROR` for truncated or malformed records.
* Preserve the original buffer when invalid input is detected.
* Return `ZIP_INTERNALERROR` if temporary buffer allocation fails.