### PR TITLE
ci: add read-only token permissions and pin all action references to SHAs

### DIFF
--- a/.github/workflows/c-std.yml
+++ b/.github/workflows/c-std.yml
@@ -8,6 +8,8 @@ on:
   push:
   pull_request:
 
+permissions: read-all
+
 jobs:
 
   main:
@@ -115,7 +117,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         show-progress: 'false'
 
@@ -226,7 +228,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         show-progress: 'false'
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,7 @@
 name: CMake
 on: [push, pull_request]
+permissions: read-all
+
 jobs:
   ci-cmake:
     name: ${{ matrix.name }}
@@ -109,7 +111,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install packages (Windows)
       if: runner.os == 'Windows'
@@ -137,7 +139,7 @@ jobs:
       run: cmake --build ../build --config ${{ matrix.build-config || 'Release' }} -t ${{ matrix.pkgtgt }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: failure()
       with:
         name: ${{ matrix.name }} (cmake)

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,5 +1,7 @@
 name: Configure
 on: [push, pull_request]
+permissions: read-all
+
 jobs:
   ci-configure:
     name: ${{ matrix.name }}
@@ -105,7 +107,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Install packages (Ubuntu)
       if: runner.os == 'Linux' && matrix.packages
@@ -137,7 +139,7 @@ jobs:
         QEMU_RUN: ${{ matrix.qemu-run }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: failure()
       with:
         name: ${{ matrix.name }} (configure)

--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -1,5 +1,7 @@
 name: contribs
 on: [push, pull_request]
+permissions: read-all
+
 jobs:
   ci-cmake:
     name: ${{ matrix.name }}
@@ -81,7 +83,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install packages
       if: runner.os == 'Linux'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,24 +1,26 @@
 name: OSS-Fuzz
 on: [pull_request]
+permissions: read-all
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
     steps:
     - name: Build Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
       with:
         oss-fuzz-project-name: 'zlib'
         dry-run: false
 
     - name: Run Fuzzers
-      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@439b356d09b53fe1161e9fe22ac42536926983db # master
       with:
         oss-fuzz-project-name: 'zlib'
         fuzz-seconds: 300
         dry-run: false
 
     - name: Upload Crash
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: failure()
       with:
         name: artifacts

--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -2,6 +2,8 @@ name: mingw/cygwin
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   MSys:
     runs-on: ${{ matrix.os || 'windows-latest' }}
@@ -18,11 +20,11 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
     - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2
       with:
         msystem: ${{ matrix.sys }}
         update: true
@@ -66,11 +68,11 @@ jobs:
     name: Cygwin
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 0
     - name: Setup cygwin
-      uses: cygwin/cygwin-install-action@master
+      uses: cygwin/cygwin-install-action@781ea34f8c7c28e794b807fb7120e93bfdac3089 # master
       with:
         packages: >-
           cmake

--- a/.github/workflows/others.yml
+++ b/.github/workflows/others.yml
@@ -2,15 +2,17 @@ name: anyVM-OSes
 
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
 
   dragonflybsd:
     runs-on: ubuntu-latest
     name: DragonflyBSD
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: DragonflyBSD
-      uses: vmactions/dragonflybsd-vm@v1
+      uses: vmactions/dragonflybsd-vm@4ba8127bd95c94b66fc4b885e37c99955ba308ea # v1
       with:
         copyback: false
         sync: scp
@@ -32,9 +34,9 @@ jobs:
           - name: aarch64
           - name: x86_64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: FreeBSD - ${{ matrix.name }}
-      uses: vmactions/freebsd-vm@v1
+      uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
       with:
         arch: ${{ matrix.name }}
         copyback: false
@@ -58,9 +60,9 @@ jobs:
           - name: aarch64
           - name: x86_64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: NetBSD - ${{ matrix.name }}
-      uses: vmactions/netbsd-vm@v1
+      uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1
       with:
         copyback: false
         sync: scp
@@ -80,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     name: OmniOS
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: OmniOS
-      uses: vmactions/omnios-vm@v1
+      uses: vmactions/omnios-vm@d42d894b41dd58cf7e31c194709a1c0fe3d04ace # v1
       with:
         copyback: false
         sync: scp
@@ -105,9 +107,9 @@ jobs:
           - name: x86_64
           - name: riscv64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: OpenBSD - ${{ matrix.name }}
-      uses: vmactions/openbsd-vm@v1
+      uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
       with:
         arch: ${{ matrix.name }}
         copyback: false
@@ -125,7 +127,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    name: OpenIndiana
 #    steps:
-#    - uses: actions/checkout@v6
+#    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 #    - name: OpenIndiana
 #      uses: vmactions/openindiana-vm@v0
 #      with:
@@ -143,9 +145,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Solaris
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - name: Solaris
-      uses: vmactions/solaris-vm@v1
+      uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1
       with:
         copyback: false
         sync: scp


### PR DESCRIPTION
## Summary

All seven CI workflows lacked a top-level `permissions:` block, so each
run inherited the repository default, which can be write-all on permissive
settings.  Every workflow now has `permissions: read-all` at the top
level, restricting the GITHUB_TOKEN to the minimum required for build and
test jobs.

In addition, every action reference that used a mutable version tag was
pinned to its full commit SHA.  A tag can be silently moved; a SHA
cannot.

### Actions pinned

| Action | From | To |
|---|---|---|
| actions/checkout | @v6 | @df4cb1c (v6.0.3) |
| actions/checkout | @v4 | @11bd719 (v4.2.2) |
| actions/upload-artifact | @v6 | @b7c566a (v6) |
| msys2/setup-msys2 | @v2 | @e989830 (v2) |
| cygwin/cygwin-install-action | @master | @781ea34 |
| vmactions/dragonflybsd-vm | @v1 | @4ba8127 |
| vmactions/freebsd-vm | @v1 | @a6de934 |
| vmactions/netbsd-vm | @v1 | @99816dc |
| vmactions/omnios-vm | @v1 | @d42d894 |
| vmactions/openbsd-vm | @v1 | @fcf799d |
| vmactions/solaris-vm | @v1 | @d30dd6c |
| google/oss-fuzz/.../build_fuzzers | @master | @439b356 |
| google/oss-fuzz/.../run_fuzzers | @master | @439b356 |

### Verification

```
uvx zizmor --min-severity medium .github/workflows/
```

Result: **0 high-severity findings** after this patch (down from 26).
The remaining 3 medium findings are style warnings about `read-all` being
broader than individual per-permission declarations — they are not a
regression and reflect the same posture as adding `permissions: read-all`
to any workflow.