### PR TITLE
ci: add permissions and pin actions to full commit SHAs

### DIFF
--- a/.github/workflows/c-std.yml
+++ b/.github/workflows/c-std.yml
@@ -8,6 +8,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
 
   main:
@@ -116,7 +119,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         show-progress: 'false'
 
@@ -240,7 +243,7 @@ jobs:
     steps:
 
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         show-progress: 'false'
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,5 +1,8 @@
 name: CMake
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   ci-cmake:
     name: ${{ matrix.name }}
@@ -109,7 +112,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Install packages (Windows)
       if: runner.os == 'Windows'
@@ -137,7 +140,7 @@ jobs:
       run: cmake --build ../build --config ${{ matrix.build-config || 'Release' }} -t ${{ matrix.pkgtgt }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: failure()
       with:
         name: ${{ matrix.name }} (cmake)

--- a/.github/workflows/configure.yml
+++ b/.github/workflows/configure.yml
@@ -1,5 +1,8 @@
 name: Configure
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   ci-configure:
     name: ${{ matrix.name }}
@@ -105,7 +108,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     - name: Install packages (Ubuntu)
       if: runner.os == 'Linux' && matrix.packages
@@ -137,7 +140,7 @@ jobs:
         QEMU_RUN: ${{ matrix.qemu-run }}
 
     - name: Upload build errors
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
       if: failure()
       with:
         name: ${{ matrix.name }} (configure)

--- a/.github/workflows/contribs.yml
+++ b/.github/workflows/contribs.yml
@@ -1,5 +1,8 @@
 name: contribs
 on: [push, pull_request]
+permissions:
+  contents: read
+
 jobs:
   ci-cmake:
     name: ${{ matrix.name }}
@@ -40,7 +43,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
     - name: Install packages
       run: |

--- a/.github/workflows/msys-cygwin.yml
+++ b/.github/workflows/msys-cygwin.yml
@@ -2,6 +2,9 @@ name: mingw/cygwin
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   MSys:
     runs-on: ${{ matrix.os || 'windows-latest' }}
@@ -18,11 +21,11 @@ jobs:
         shell: msys2 {0}
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0
     - name: Setup MSYS2
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2
       with:
         msystem: ${{ matrix.sys }}
         update: true
@@ -66,11 +69,11 @@ jobs:
     name: Cygwin
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       with:
         fetch-depth: 0
     - name: Setup cygwin
-      uses: cygwin/cygwin-install-action@master
+      uses: cygwin/cygwin-install-action@781ea34f8c7c28e794b807fb7120e93bfdac3089 # master
       with:
         packages: >-
           cmake

--- a/.github/workflows/others.yml
+++ b/.github/workflows/others.yml
@@ -2,15 +2,18 @@ name: anyVM-OSes
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   dragonflybsd:
     runs-on: ubuntu-latest
     name: DragonflyBSD
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: DragonflyBSD
-      uses: vmactions/dragonflybsd-vm@v1
+      uses: vmactions/dragonflybsd-vm@4ba8127bd95c94b66fc4b885e37c99955ba308ea # v1
       with:
         copyback: false
         prepare: |
@@ -31,9 +34,9 @@ jobs:
           - name: aarch64
           - name: x86_64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: FreeBSD - ${{ matrix.name }}
-      uses: vmactions/freebsd-vm@v1
+      uses: vmactions/freebsd-vm@a6de9343ef5747433d9c25784c90e84998b9d69a # v1
       with:
         arch: ${{ matrix.name }}
         copyback: false
@@ -56,9 +59,9 @@ jobs:
           - name: aarch64
           - name: x86_64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: NetBSD - ${{ matrix.name }}
-      uses: vmactions/netbsd-vm@v1
+      uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1
       with:
         copyback: false
         prepare: |
@@ -77,9 +80,9 @@ jobs:
     runs-on: ubuntu-latest
     name: OmniOS
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: OmniOS
-      uses: vmactions/omnios-vm@v1
+      uses: vmactions/omnios-vm@7f2be0b927aad1a78498c8aeeac4c4ce1fabd322 # v1
       with:
         copyback: false
         prepare: |
@@ -101,9 +104,9 @@ jobs:
           - name: x86_64
           - name: riscv64
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: OpenBSD - ${{ matrix.name }}
-      uses: vmactions/openbsd-vm@v1
+      uses: vmactions/openbsd-vm@fcf799d7ce9c305ad89eabef1fb2fa5c1c42d0ee # v1
       with:
         arch: ${{ matrix.name }}
         copyback: false
@@ -120,7 +123,7 @@ jobs:
 #    runs-on: ubuntu-latest
 #    name: OpenIndiana
 #    steps:
-#    - uses: actions/checkout@v6
+#    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 #    - name: OpenIndiana
 #      uses: vmactions/openindiana-vm@v0
 #      with:
@@ -137,9 +140,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Solaris
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
     - name: Solaris
-      uses: vmactions/solaris-vm@v1
+      uses: vmactions/solaris-vm@d30dd6c228c8661ade859e36ead7660b9a62efcc # v1
       with:
         copyback: false
         release: "11.4-gcc"


### PR DESCRIPTION
All 6 non-fuzz workflow files were missing a top-level `permissions:` block and used mutable tag references (`@v6`, `@master`, `@v1`, etc.).

**Add `permissions: contents: read`** to each workflow (principle of least privilege).

**Pin all `uses:` to full commit SHAs** (tags kept as comments):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6` / `@v4` | `@df4cb1c0` / `@34e11487` |
| `actions/upload-artifact` | `@v6` | `@b7c566a7` |
| `msys2/setup-msys2` | `@v2` | `@66cd2cce` |
| `cygwin/cygwin-install-action` | `@master` | `@781ea34f` |
| `vmactions/dragonflybsd-vm` | `@v1` | `@4ba8127b` |
| `vmactions/freebsd-vm` | `@v1` | `@a6de9343` |
| `vmactions/netbsd-vm` | `@v1` | `@99816dcc` |
| `vmactions/omnios-vm` | `@v1` | `@7f2be0b9` |
| `vmactions/openbsd-vm` | `@v1` | `@fcf799d7` |
| `vmactions/solaris-vm` | `@v1` | `@d30dd6c2` |

Qualifies under the [Google Open Source Patch Rewards Program](https://bughunters.google.com/open-source-security/patch-rewards).