### PR TITLE
Fix CMake error about source directory not existing

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -161,7 +161,7 @@ if(ZLIB_INSTALL)
 
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/find_package_wrong_components_test.cmake.in
-        ${CMAKE_CURRENT_BINARY_DIR}/zlib_findpackage_wrong_components_test/CMakeLists.txt
+        ${CMAKE_CURRENT_BINARY_DIR}/zlib_find_package_wrong_components_test/CMakeLists.txt
         @ONLY)
 
     configure_file(
@@ -239,7 +239,7 @@ if(ZLIB_INSTALL)
     endif(NOT ZLIB_BUILD_SHARED OR NOT ZLIB_BUILD_STATIC)
 
     #
-    # find_package_no_component_test
+    # find_package_wrong_components_test
     #
     add_test(
         NAME zlib_find_package_wrong_components_configure


### PR DESCRIPTION
When I run the zlib tests, I get:
```
test 7
      Start  7: zlib_find_package_wrong_components_configure

7: Test command: /opt/homebrew/bin/cmake "-B/Users/brenton/development/github/tbt-parser/build/_deps/zlib-build/test/zlib_find_package_wrong_components_test_build" "-DCMAKE_BUILD_TYPE=" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_C_FLAGS=" "-DCMAKE_INSTALL_PREFIX=/Users/brenton/development/github/tbt-parser/build/_deps/zlib-build/test/test_install" "--fresh" "-G" "Unix Makefiles" "-S/Users/brenton/development/github/tbt-parser/build/_deps/zlib-build/test/zlib_find_package_wrong_components_test"
7: Working Directory: /Users/brenton/development/github/tbt-parser/build/lib/../_deps/zlib-build/test
7: Test timeout computed to be: 10000000
7: CMake Error: The source directory "/Users/brenton/development/github/tbt-parser/build/_deps/zlib-build/test/zlib_find_package_wrong_components_test" does not exist.
7: Specify --help for usage, or press the help button on the CMake GUI.
 7/36 Test  #7: zlib_find_package_wrong_components_configure ...   Passed    0.00 sec
```

Notice:
```
CMake Error: The source directory "/Users/brenton/development/github/tbt-parser/build/_deps/zlib-build/test/zlib_find_package_wrong_components_test" does not exist.
```

It looks like commit b2ed1975cf6dbbab61e20d5d8c41f82e9f64f285 did not update everything in test/CMakeLists.txt.