### PR TITLE
Add a new --cross-prefix option to configure for pwsh users.

### DIFF
--- a/configure
+++ b/configure
@@ -152,6 +152,12 @@ case "$1" in
     -c* | --const) zconst=1; shift ;;
     -w* | --warn) warn=$((warn + 1)); shift ;;
     -d* | --debug) debug=1; shift ;;
+    # This option in configure is needed as passing CHOST from powershell core
+    # on linux to the configure script is not possible without this. And some
+    # people invoke configure within a common powershell build script that
+    # allows building their code for Windows, Linux, and MacOS with the least
+    # amount of files just for building their project.
+    --cross-prefix) CROSS_PREFIX="$2"; shift; shift ;;
     --sanitize) address=1; shift ;;
     --address) address=1; shift ;;
     --memory) memory=1; shift ;;


### PR DESCRIPTION
Added the --cross-prefix option into the configure script with comments explaining why.

@madler I am sorry for this PR but I needed this option to properly build a static lib for linking into my shared library for x86, x64, arm, and arm64 builds of gcc/g++ using cross-compiler packages.

Sadly since after forever when one needs to install the cross compilers it results in:
- uninstall of gcc-multilib, normal gcc, and g++
- install of the cross compiler (since they conflict with gcc-multilib so marks them for removal which breaks normal ``$CC``.
  - This means that once they install a single cross-compiler package they must replace all of the C/C++ compilers with cross-compilers for x86, x64, arm, arm64, longarch64, etc.

The fix:
- Adding a ``--cross-prefix`` option to configure to resolve this issue.