### PR TITLE
Remove RCS keywords

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,32 +44,16 @@ include(GNUInstallDirs)
 
 set(CPACK_INCLUDED TRUE)
 
-if(NOT ZLIB_CONF_WRITTEN)
-    set(Z_PREFIX ${ZLIB_PREFIX})
-    set(CONF_OUT_FILE ${zlib_BINARY_DIR}/zconf.h.cmakein)
-    file(READ ${zlib_SOURCE_DIR}/zconf.h ZCONF_CONTENT LIMIT 245)
-    file(WRITE ${CONF_OUT_FILE} ${ZCONF_CONTENT})
-    file(APPEND ${CONF_OUT_FILE} "#cmakedefine Z_PREFIX 1\n")
-    file(APPEND ${CONF_OUT_FILE} "#cmakedefine HAVE_STDARG_H 1\n")
-    file(APPEND ${CONF_OUT_FILE} "#cmakedefine HAVE_UNISTD_H 1\n")
-    file(READ ${zlib_SOURCE_DIR}/zconf.h ZCONF_CONTENT OFFSET 244)
-    set(FIRST_ITEM TRUE)
+set(Z_PREFIX ${ZLIB_PREFIX})
 
-    foreach(item IN LISTS ZCONF_CONTENT)
-        if(FIRST_ITEM)
-            string(APPEND OUT_CONTENT ${item})
-            set(FIRST_ITEM FALSE)
-        else(FIRST_ITEM)
-            string(APPEND OUT_CONTENT "\;" ${item})
-        endif(FIRST_ITEM)
-    endforeach(item IN LISTS ${ZCONF_CONTENT})
-
-    file(APPEND ${CONF_OUT_FILE} ${OUT_CONTENT})
-    set(ZLIB_CONF_WRITTEN
-        TRUE
-        CACHE BOOL "zconf.h.cmakein was created")
-    mark_as_advanced(ZLIB_CONF_WRITTEN)
-endif(NOT ZLIB_CONF_WRITTEN)
+file(READ ${zlib_SOURCE_DIR}/zconf.h zconf_content)
+set(zconf_inc_guard "#define ZCONF_H\n")
+string(CONCAT zconf_new_content
+    "#cmakedefine Z_PREFIX 1\n"
+    "#cmakedefine HAVE_STDARG_H 1\n"
+    "#cmakedefine HAVE_UNISTD_H 1\n")
+string(REPLACE "${zconf_inc_guard}" "${zconf_inc_guard}\n${zconf_new_content}"
+    zconf_cmake_in "${zconf_content}")
 
 #
 # Check to see if we have large file support
@@ -123,7 +107,8 @@ else()
     set(pc_libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
 endif()
 configure_file(${zlib_SOURCE_DIR}/zlib.pc.cmakein ${ZLIB_PC} @ONLY)
-configure_file(${zlib_BINARY_DIR}/zconf.h.cmakein ${zlib_BINARY_DIR}/zconf.h)
+string(CONFIGURE "${zconf_cmake_in}" zconf_configured)
+file(GENERATE OUTPUT ${zlib_BINARY_DIR}/zconf.h CONTENT "${zconf_configured}")
 
 # ============================================================================
 # zlib

--- a/adler32.c
+++ b/adler32.c
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #include "zutil.h"
 
 #define BASE 65521U     /* largest prime smaller than 65536 */

--- a/compress.c
+++ b/compress.c
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #define ZLIB_INTERNAL
 #include "zlib.h"
 

--- a/crc32.c
+++ b/crc32.c
@@ -7,8 +7,6 @@
  * Kadatch and Jenkins (2010). See doc/crc-doc.1.0.pdf in this distribution.
  */
 
-/* @(#) $Id$ */
-
 /*
   Note on the use of DYNAMIC_CRC_TABLE: there is no mutex or semaphore
   protection on the static variables used to control the first-use generation

--- a/deflate.c
+++ b/deflate.c
@@ -47,8 +47,6 @@
  *
  */
 
-/* @(#) $Id$ */
-
 #include "deflate.h"
 
 const char deflate_copyright[] =

--- a/deflate.h
+++ b/deflate.h
@@ -8,8 +8,6 @@
    subject to change. Applications should only use zlib.h.
  */
 
-/* @(#) $Id$ */
-
 #ifndef DEFLATE_H
 #define DEFLATE_H
 

--- a/test/example.c
+++ b/test/example.c
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #if defined(_WIN32) && !defined(_CRT_SECURE_NO_WARNINGS)
 #  define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/test/minigzip.c
+++ b/test/minigzip.c
@@ -13,8 +13,6 @@
  * or in pipe mode.
  */
 
-/* @(#) $Id$ */
-
 #ifndef _POSIX_C_SOURCE
 #  define _POSIX_C_SOURCE 200112L
 #endif

--- a/trees.c
+++ b/trees.c
@@ -30,8 +30,6 @@
  *          Addison-Wesley, 1983. ISBN 0-201-06672-6.
  */
 
-/* @(#) $Id$ */
-
 /* #define GEN_TREES_H */
 
 #include "deflate.h"

--- a/uncompr.c
+++ b/uncompr.c
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #define ZLIB_INTERNAL
 #include "zlib.h"
 

--- a/zconf.h
+++ b/zconf.h
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #ifndef ZCONF_H
 #define ZCONF_H
 

--- a/zconf.h.in
+++ b/zconf.h.in
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #ifndef ZCONF_H
 #define ZCONF_H
 

--- a/zutil.c
+++ b/zutil.c
@@ -3,8 +3,6 @@
  * For conditions of distribution and use, see copyright notice in zlib.h
  */
 
-/* @(#) $Id$ */
-
 #include "zutil.h"
 #ifndef Z_SOLO
 #  include "gzguts.h"

--- a/zutil.h
+++ b/zutil.h
@@ -8,8 +8,6 @@
    subject to change. Applications should only use zlib.h.
  */
 
-/* @(#) $Id$ */
-
 #ifndef ZUTIL_H
 #define ZUTIL_H
 


### PR DESCRIPTION
This PR builds upon #1277 and also removes the RCS keywords from source files. The changes to the CMakeLists.txt are necessary for the removal or else the build breaks.

Fixes #1232.