### PR TITLE
minizip: fix heap-buffer-overflow in zipRemoveExtraInfoBlock

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -2212,8 +2212,20 @@ extern int ZEXPORT zipRemoveExtraInfoBlock(char* pData, int* dataLen, short sHea
 
   while(p < (pData + *dataLen))
   {
+    if ((pData + *dataLen) - p < 4)
+    {
+      free(pNewHeader);
+      return ZIP_PARAMERROR;
+    }
+
     header = *(short*)p;
     dataSize = *(((short*)p)+1);
+
+    if (dataSize < 0 || dataSize + 4 > (pData + *dataLen) - p)
+    {
+      free(pNewHeader);
+      return ZIP_PARAMERROR;
+    }
 
     if( header == sHeader ) /* Header found. */
     {


### PR DESCRIPTION
Fixes #1276.

`zipRemoveExtraInfoBlock()` in `contrib/minizip/zip.c` read a 2-byte
block-size field directly from the input buffer and used it unchecked
as both a `memcpy` length and a pointer-advance amount, with no
validation against the buffer's actual remaining size (`*dataLen`).
An attacker-controlled extra-field blob can drive the read cursor and
the `memcpy` length past the end of the buffer.

This adds a bounds check before each block header is consumed:
- bail out with `ZIP_PARAMERROR` if fewer than 4 bytes remain in the
  buffer for the header + size field
- bail out with `ZIP_PARAMERROR` if the declared block size
  (`dataSize + 4`) exceeds what is actually left in the buffer

## Testing

Reproducer from #1276, built with ASan/UBSan:

```
==ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 32771 at ... in a 4-byte allocation
    #1 zipRemoveExtraInfoBlock zip.c:1980
```

- Before the fix: aborts under ASan as shown above.
- After the fix: reproducer runs clean, returns `ZIP_PARAMERROR`.
- Regression check: a buffer with two well-formed 4-byte blocks
  (one matching the removal header, one not) still round-trips
  correctly — the surviving block is copied through unmodified and
  the new length is reported correctly. Normal block-removal
  behavior is unchanged.