### PR TITLE
Return on a stalled non-blocking gzprintf write

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -444,6 +444,7 @@ int ZEXPORTVA gzvprintf(gzFile file, const char *format, va_list va) {
                a Z_BUF_ERROR to let the application know that this gzprintf()
                needs to be retried. */
             gz_error(state, Z_BUF_ERROR, "stalled write on gzprintf");
+            return state->err;
         }
         if (!state->again)
             return state->err;
@@ -552,6 +553,7 @@ int ZEXPORTVA gzprintf(gzFile file, const char *format, int a1, int a2, int a3,
                a Z_BUF_ERROR to let the application know that this gzprintf()
                needs to be retried. */
             gz_error(state, Z_BUF_ERROR, "stalled write on gzprintf");
+            return state->err;
         }
         if (!state->again)
             return state->err;


### PR DESCRIPTION
## Summary

- return `Z_BUF_ERROR` immediately when a formatted gzip write stalls on a non-blocking destination
- apply the same control-flow fix to both `gzvprintf()` and the legacy C89 `gzprintf()` implementation
- preserve the existing retry contract instead of continuing to copy the same input into an exhausted output buffer

Fixes #1256.

## Root cause

When pending gzip output cannot be flushed, both formatted-write paths record `Z_BUF_ERROR` but continue processing the same input. The write cursor can remain at the end of the allocation, allowing the following copy to write beyond the heap buffer.

Returning the recorded error at the stall point lets the caller wait for the descriptor to become writable and retry the same formatted write.

## Validation

- reproduced the untouched heap-buffer-overflow with a deterministic non-blocking pipe proof under AddressSanitizer
- verified the patched sanitizer and release builds return `Z_BUF_ERROR`, successfully retry the same write after draining the pipe, and close with `Z_OK`
- `make -j4 test`
- `make -j4 testshared`
