### PR TITLE
Allow overriding of installation directory for CMake configuration files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,12 @@ if(WIN32)
     set(CMAKE_DEBUG_POSTFIX "d")
 endif(WIN32)
 
+# Set directory for installed CMake configuration files
+if(NOT DEFINED ZLIB_INSTALL_CMAKEDIR)
+  set(ZLIB_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/zlib"
+      CACHE STRING "Directory to install zlib CMake configuration files to")
+endif()
+
 if(ZLIB_BUILD_SHARED)
     add_library(
         zlib SHARED ${ZLIB_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS}
@@ -268,7 +274,7 @@ if(ZLIB_INSTALL)
             EXPORT zlibSharedExport
             FILE ZLIB-shared.cmake
             NAMESPACE ZLIB::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zlib)
+            DESTINATION ${ZLIB_INSTALL_CMAKEDIR})
 
         if(MSVC)
             install(
@@ -292,13 +298,13 @@ if(ZLIB_INSTALL)
             EXPORT zlibStaticExport
             FILE ZLIB-static.cmake
             NAMESPACE ZLIB::
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zlib)
+            DESTINATION ${ZLIB_INSTALL_CMAKEDIR})
     endif(ZLIB_BUILD_STATIC)
 
     configure_package_config_file(
         ${zlib_SOURCE_DIR}/zlibConfig.cmake.in
         ${zlib_BINARY_DIR}/ZLIBConfig.cmake
-        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zlib)
+        INSTALL_DESTINATION ${ZLIB_INSTALL_CMAKEDIR})
 
     write_basic_package_version_file(
         "${zlib_BINARY_DIR}/ZLIBConfigVersion.cmake"
@@ -307,7 +313,7 @@ if(ZLIB_INSTALL)
 
     install(FILES ${zlib_BINARY_DIR}/ZLIBConfig.cmake
                   ${zlib_BINARY_DIR}/ZLIBConfigVersion.cmake
-            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zlib)
+            DESTINATION ${ZLIB_INSTALL_CMAKEDIR})
     install(
         FILES ${ZLIB_PUBLIC_HDRS}
         COMPONENT Development


### PR DESCRIPTION
When building zlib as a sub-project within another CMake project, it can be useful to override where the CMake configuration files will be installed. This can allow vendoring a zlib installation while avoiding the potential problem of overwriting system zlib CMake configuration files when the encompassing project is installed with a system-wide `CMAKE_INSTALL_PREFIX`. See https://gitlab.dkrz.de/dkrz-sw/libaec/-/blob/main/packaging/CMakeLists.txt?ref_type=heads#L4 for similar logic that was added to libaec (not by myself). This adds a CMake cache variable `ZLIB_INSTALL_CMAKEDIR` which can be used to override the installation location if desired.

I notice that there's another occurrence of `${CMAKE_INSTALL_LIBDIR}/cmake/zlib` in `contrib/zlib1-dll/CMakeLists.txt` but it was unclear to me if that occurrence was a typo that was meant to be `${CMAKE_INSTALL_LIBDIR}/cmake/zlib1dll` instead (based on surrounding code). If the directory is correct as `${CMAKE_INSTALL_LIBDIR}/cmake/zlib`, I can change that occurrence to use `ZLIB_INSTALL_CMAKEDIR` as well.