### PR TITLE
Avoid retaining caller input after gzwrite

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -242,9 +242,17 @@ local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
             n -= state->strm.avail_in;
             state->x.pos += n;
             len -= n;
-            if (ret == -1)
+            if (ret == -1) {
+                /*
+                 * The bytes not reported as consumed remain owned by the
+                 * caller. Do not keep their address after returning.
+                 */
+                state->strm.avail_in = 0;
+                state->strm.next_in = Z_NULL;
                 return state->again ? put - len : 0;
+            }
         } while (len);
+        state->strm.next_in = Z_NULL;
     }
 
     /* input was all buffered or compressed */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,12 @@ if(ZLIB_BUILD_STATIC)
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
     add_test(NAME zlib_examplestatic COMMAND zlib_examplestatic)
 
+    if(UNIX)
+        add_executable(gznonblock gznonblock.c)
+        target_link_libraries(gznonblock ZLIB::ZLIBSTATIC)
+        add_test(NAME zlib_gznonblock COMMAND gznonblock)
+    endif(UNIX)
+
     add_executable(zlib_minigzipstatic minigzip.c)
     target_link_libraries(zlib_minigzipstatic ZLIB::ZLIBSTATIC)
     set_target_properties(zlib_minigzipstatic

--- a/test/gznonblock.c
+++ b/test/gznonblock.c
@@ -1,0 +1,90 @@
+/* gznonblock.c -- test non-blocking gzip writes
+ * Copyright (C) 2026 Mark Adler
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zlib.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define INPUT_SIZE (1024 * 1024)
+
+int main(void) {
+    int pipefd[2];
+    unsigned char fill[4096];
+    unsigned char *input;
+    unsigned seed;
+    size_t i;
+    gzFile file;
+    int put;
+
+    if (pipe(pipefd) == -1 ||
+        fcntl(pipefd[1], F_SETFL,
+              fcntl(pipefd[1], F_GETFL) | O_NONBLOCK) == -1) {
+        perror("pipe");
+        return 1;
+    }
+
+    memset(fill, 0xa5, sizeof(fill));
+    while (write(pipefd[1], fill, sizeof(fill)) > 0)
+        ;
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        perror("fill pipe");
+        return 1;
+    }
+
+    /*
+     * Use incompressible input larger than the gzip buffers so that the full
+     * pipe stalls gzwrite() before it consumes the caller's entire buffer.
+     */
+    input = (unsigned char *)malloc(INPUT_SIZE);
+    if (input == NULL) {
+        fprintf(stderr, "out of memory\n");
+        return 1;
+    }
+    seed = 0x12345678U;
+    for (i = 0; i < INPUT_SIZE; i++) {
+        seed ^= seed << 13;
+        seed ^= seed >> 17;
+        seed ^= seed << 5;
+        input[i] = (unsigned char)seed;
+    }
+
+    file = gzdopen(pipefd[1], "wbN");
+    if (file == NULL) {
+        fprintf(stderr, "gzdopen failed\n");
+        return 1;
+    }
+
+    put = gzwrite(file, input, INPUT_SIZE);
+    free(input);
+    if (put <= 0 || put >= INPUT_SIZE) {
+        fprintf(stderr, "gzwrite did not make partial progress: %d\n", put);
+        return 1;
+    }
+
+    /*
+     * gzwrite() reported the remaining input as unconsumed, so the caller was
+     * allowed to release it. A following gzip operation must not access it.
+     */
+    put = gzprintf(file, "%s", "X");
+    if (put != 1) {
+        fprintf(stderr, "gzprintf failed after partial gzwrite: %d\n", put);
+        return 1;
+    }
+
+    if (fcntl(pipefd[0], F_SETFL,
+              fcntl(pipefd[0], F_GETFL) | O_NONBLOCK) == -1) {
+        perror("read pipe");
+        return 1;
+    }
+    while (read(pipefd[0], fill, sizeof(fill)) > 0)
+        ;
+    (void)gzclose(file);
+    close(pipefd[0]);
+    return 0;
+}


### PR DESCRIPTION
## Summary

- clear `next_in` before returning from a completed direct `gzwrite`
- clear both `next_in` and `avail_in` before returning from a stalled direct `gzwrite`
- add a deterministic regression test using a full non-blocking pipe

## Root cause

For a large input, `gz_write()` compresses directly from the caller buffer. On return it retained an address into that external allocation.

When a non-blocking destination stalls, `gzwrite()` returns the number of bytes consumed but leaves the unconsumed portion in `strm->next_in` and `strm->avail_in`. The API reports those bytes as unconsumed, so the caller may release or reuse them before retrying. A later `gzprintf()` can then reach `gz_vacate()` and move the stale external input into the much smaller internal buffer.

After a completed direct write, `next_in` similarly remains one past the caller allocation. A later `gz_vacate()` performs a relational comparison between that stale external pointer and the internal input allocation, which is undefined. Clang AddressSanitizer with invalid-pointer-pair detection reproduces this after the caller releases the completed input.

The fix drops the external input reference before every return from the direct-write path. The reported byte count is unchanged, so callers can retry an unconsumed tail as documented.

This path is independent of #1281: applying that change alone still reproduces the stale caller-buffer access before its new return path is reached.

## Validation

- untouched `develop`: deterministic ASan heap-use-after-free, reading 983040 bytes after a partial-write caller frees the unconsumed input
- #1281 applied alone: same deterministic ASan heap-use-after-free
- untouched `develop`: deterministic ASan invalid-pointer-pair after a completed direct write and caller free
- patched targeted ASan/UBSan/pointer-compare reproducer: passes
- patched Clang ASan/UBSan build: regression test and full static CTest pass
- patched GCC `-Wall -Wextra -Werror` build: 16/16 CTest tests pass
- patched OSS-Fuzz harnesses: no sanitizer failure in the bounded runs