### PR TITLE
Avoid crc32 narrowing warning

### DIFF
--- a/crc32.c
+++ b/crc32.c
@@ -686,7 +686,7 @@ uLong ZEXPORT crc32_z(uLong crc, const unsigned char FAR *buf, z_size_t len) {
 #endif
 
             /* Initialize the CRC for each braid. */
-            crc0 = crc;
+            crc0 = (z_crc_t)crc;
 #if N > 1
             crc1 = 0;
 #if N > 2


### PR DESCRIPTION
Fixes #1287.

`crc` is masked to 32 bits before the braided path, so this conversion is intentional. Make it explicit to avoid the Clang `-Wshorten-64-to-32` warning.

Tested with a Clang build using `-Wshorten-64-to-32 -Werror`, followed by the CMake tests on Linux and Windows.