### PR TITLE
Fix memory leak in minizip's zipOpen3 function

### DIFF
--- a/contrib/minizip/zip.c
+++ b/contrib/minizip/zip.c
@@ -1055,6 +1055,11 @@ local int LoadCentralDirectoryRecord(zip64_internal* pziinit) {
   if (ZSEEK64(pziinit->z_filefunc, pziinit->filestream, offset_central_dir+byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET) != 0)
     err=ZIP_ERRNO;
 
+  if (err != ZIP_OK)
+  {
+    ZCLOSE64(pziinit->z_filefunc, pziinit->filestream);
+  }
+
   return err;
 }
 
@@ -1123,6 +1128,7 @@ extern zipFile ZEXPORT zipOpen3(const void *pathname, int append, zipcharpc* glo
     {
 #    ifndef NO_ADDFILEINEXISTINGZIP
         free(ziinit.globalcomment);
+        free_linkedlist(&(ziinit.central_dir));
 #    endif /* !NO_ADDFILEINEXISTINGZIP*/
         free(zi);
         return NULL;


### PR DESCRIPTION
## Summary

When `zipOpen3()` is called with `APPEND_STATUS_ADDINZIP` and `LoadCentralDirectoryRecord()` fails after partially reading the central directory, the error path leaks the datablock list and the file stream. Fixes #1223.

## Root Cause

The `zipOpen3()` error path freed `ziinit.globalcomment` and `zi`, but never called `free_linkedlist(&ziinit.central_dir)`. The filestream was also only closed on `LoadCentralDirectoryRecord()`'s early-return path, not on its final error return, so it leaked on the later seek/read failures.

## Fix

- `LoadCentralDirectoryRecord()`: close the filestream on its final error return, matching the existing early-error handling.
- `zipOpen3()`: call `free_linkedlist(&(ziinit.central_dir))` on the error path.

## Verification

ASan before:

```text
=================================================================
==113671==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 4112 byte(s) in 1 object(s) allocated from:
    #1 0x... in allocate_new_datablock zip.c:210
    #2 0x... in add_data_in_datablock zip.c:248
    #3 0x... in LoadCentralDirectoryRecord zip.c:1046
    #4 0x... in zipOpen3 zip.c:1113
SUMMARY: AddressSanitizer: 4112 byte(s) leaked in 1 allocation(s).
```

After: no leak, and the leaked file descriptor count returns to baseline.