### PR TITLE
Enable shared lib through configure on Windows

### DIFF
--- a/configure
+++ b/configure
@@ -305,6 +305,8 @@ if test "$gcc" -eq 1 && ($cc -c $test.c) >> configure.log 2>&1; then
         echo "If this doesn't work for you, try win32/Makefile.gcc." | tee -a configure.log
         LDSHARED=${LDSHARED-"$cc -shared"}
         LDSHAREDLIBC=""
+        shared_ext='.dll'
+        SHAREDLIB='libz.dll'
         EXE='.exe' ;;
   QNX*) # This is for QNX6. I suppose that the QNX rule below is for QNX2,QNX4
         # (alain.bonnefoy@icbt.com)


### PR DESCRIPTION
This helps to enable Windows build targets to use the configure script,
setting the proper extension for the shared libraries and setting the
library name to match its name on other systems.
