### PR TITLE
inflate: total_in misses the header bytes on Z_NEED_DICT

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -700,6 +700,7 @@ int ZEXPORT inflate(z_streamp strm, int flush) {
         case DICT:
             if (state->havedict == 0) {
                 RESTORE();
+                strm->total_in += in - strm->avail_in;
                 return Z_NEED_DICT;
             }
             strm->adler = state->check = adler32(0L, Z_NULL, 0);

--- a/test/example.c
+++ b/test/example.c
@@ -479,6 +479,11 @@ static void test_dict_inflate(Byte *compr, uLong comprLen, Byte *uncompr,
         CHECK_ERR(err, "inflate with dict");
     }
 
+    if (d_stream.total_in != comprLen - d_stream.avail_in) {
+        fprintf(stderr, "bad total_in after dictionary inflate\n");
+        exit(1);
+    }
+
     err = inflateEnd(&d_stream);
     CHECK_ERR(err, "inflateEnd");
 


### PR DESCRIPTION
`case DICT:` returns via `RESTORE(); return Z_NEED_DICT;` without reaching `inf_leave`, so the six header + DICTID bytes it consumed are never added to `total_in`. It stays six short through `Z_STREAM_END`.

No affected caller found.

The added check in `test/example.c` fails without the fix.