### PR TITLE
[codex] Avoid retaining caller input after non-blocking gzwrite stall

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -183,7 +183,7 @@ local int gz_zero(gz_statep state) {
 
 /* Write len bytes from buf to file.  Return the number of bytes written.  If
    the returned value is less than len, then there was an error. If the error
-   was a non-blocking stall, then the number of bytes consumed is returned.
+   was a non-blocking stall, then the number of bytes accepted is returned.
    For any other error, 0 is returned. */
 local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
     z_size_t put = len;
@@ -242,8 +242,25 @@ local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
             n -= state->strm.avail_in;
             state->x.pos += n;
             len -= n;
-            if (ret == -1)
-                return state->again ? put - len : 0;
+            if (ret == -1) {
+                if (state->again) {
+                    /* Save an accepted prefix of the remaining input.  Never
+                       leave next_in pointing into the caller's buffer after
+                       returning. */
+                    unsigned save = state->strm.avail_in;
+
+                    if (save > state->size)
+                        save = state->size;
+                    if (save)
+                        memcpy(state->in, state->strm.next_in, save);
+                    state->strm.next_in = state->in;
+                    state->strm.avail_in = save;
+                    state->x.pos += save;
+                    len -= save;
+                    return put - len;
+                }
+                return 0;
+            }
         } while (len);
     }
 


### PR DESCRIPTION
## Summary

- avoid retaining caller-owned input after a non-blocking `gzwrite()` stall
- save a bounded accepted prefix in zlib's internal input buffer
- include the saved bytes in the return value and stream position

Fixes #1292.

## Root cause

The large-write path points `strm.next_in` directly at the caller's buffer.
If writing compressed output stalls with `EAGAIN`, `gz_comp()` returns while
`next_in` and `avail_in` still describe the unconsumed caller input. A later
small `gzwrite()` or `gzputc()` assumes that pending input belongs to
`state->in`, performs pointer arithmetic across unrelated allocations, and
can write out of bounds.

Leaving the caller pointer pending for a later retry is also not sufficient:
the caller may release that buffer after the partial return, and retrying the
reported remainder would duplicate data once zlib consumed the retained input.

On a non-blocking stall, this change accepts at most one internal buffer of the
remaining input, copies that prefix into zlib-owned storage, and reports those
bytes as accepted. The caller retains responsibility for the rest.

## Impact

This restores the internal-buffer invariant before the public write call
returns, preventing the out-of-bounds write and the related stale-pointer
read while preserving partial-write semantics for compressed and transparent
output.

## Validation

- deterministic Linux ASan/UBSan reproduction before the fix: SEGV in
  `memcpy()` from `gz_write()` at `gzwrite.c:217`
- the same trigger completes without a sanitizer finding after the fix
- differential non-blocking round trip verifies that accepted input appears
  exactly once, without loss or duplication
- strict C89 compilation with `-Wall -Wextra -Werror`
- `./configure && make -j2 test` (static, shared, and 64-bit tests)
