### PR TITLE
Avoid overflow after a stalled gzprintf write.

### DIFF
--- a/gzwrite.c
+++ b/gzwrite.c
@@ -211,6 +211,11 @@ local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
                 state->strm.next_in = state->in;
             have = (unsigned)((state->strm.next_in + state->strm.avail_in) -
                               state->in);
+            if (have >= state->size) {
+                if (gz_comp(state, Z_NO_FLUSH) == -1)
+                    return state->again ? put - len : 0;
+                continue;
+            }
             copy = state->size - have;
             if (copy > len)
                 copy = (unsigned)len;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -69,6 +69,12 @@ if(ZLIB_BUILD_STATIC)
                 $<$<BOOL:${HAVE___ATTR__VIS_HIDDEN}>:HAVE_HIDDEN>)
     add_test(NAME zlib_examplestatic COMMAND zlib_examplestatic)
 
+    if(UNIX)
+        add_executable(zlib_gzprintfwrite gzprintfwrite.c)
+        target_link_libraries(zlib_gzprintfwrite ZLIB::ZLIBSTATIC)
+        add_test(NAME zlib_gzprintfwrite COMMAND zlib_gzprintfwrite)
+    endif(UNIX)
+
     add_executable(zlib_minigzipstatic minigzip.c)
     target_link_libraries(zlib_minigzipstatic ZLIB::ZLIBSTATIC)
     set_target_properties(zlib_minigzipstatic

--- a/test/gzprintfwrite.c
+++ b/test/gzprintfwrite.c
@@ -1,0 +1,55 @@
+/* gzprintfwrite.c -- test a non-blocking gzprintf followed by gzwrite
+ * Copyright (C) 2026 Mark Adler
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+#include "zlib.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void) {
+    int pipefd[2];
+    unsigned char fill[4096];
+    gzFile file;
+    int put;
+
+    if (pipe(pipefd) == -1 ||
+        fcntl(pipefd[1], F_SETFL,
+              fcntl(pipefd[1], F_GETFL) | O_NONBLOCK) == -1) {
+        perror("pipe");
+        return 1;
+    }
+
+    memset(fill, 0xa5, sizeof(fill));
+    while (write(pipefd[1], fill, sizeof(fill)) > 0)
+        ;
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        perror("fill pipe");
+        return 1;
+    }
+
+    file = gzdopen(pipefd[1], "wbN");
+    if (file == NULL || gzbuffer(file, 8) != 0) {
+        fprintf(stderr, "gzip setup failed\n");
+        return 1;
+    }
+
+    if (gzprintf(file, "%s", "123456") != 6 ||
+        gzprintf(file, "%s", "abcdef") != 6) {
+        fprintf(stderr, "gzprintf did not reach the expected stalled state\n");
+        return 1;
+    }
+
+    put = gzwrite(file, "ABCDEFG", 7);
+    if (put != 0) {
+        fprintf(stderr, "gzwrite consumed input while the gzip input buffer was stalled: %d\n", put);
+        return 1;
+    }
+
+    (void)gzclose(file);
+    close(pipefd[0]);
+    return 0;
+}


### PR DESCRIPTION
This fixes an overflow in the buffered `gzwrite()` path after a non-blocking `gzprintf()` stalls with more than `state->size` bytes pending in the double-sized input buffer.

Previously, the small-write path computed `state->size - have` without first handling `have >= state->size`, so the subtraction could underflow and lead to a copy past the input allocation. The fix first attempts to drain the pending input with `gz_comp()` and returns the non-blocking stall without consuming caller input when the output cannot make progress.

A focused regression test fills a non-blocking pipe, uses a small gzip buffer, performs two `gzprintf()` calls to reach the stalled state, and verifies that a following `gzwrite()` consumes no input.

Validation performed locally:
- static CMake build passes;
- all 14 CTest tests pass, including the new `zlib_gzprintfwrite` test;
- the regression test fails against the unpatched base;
- ASan reproduces the heap-buffer-overflow before the fix and no overflow occurs on the corrected path.
