### PR TITLE
Reject a null dictionary in inflateSetDictionary().

### DIFF
--- a/inflate.c
+++ b/inflate.c
@@ -1191,7 +1191,8 @@ int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef *dictionary,
     int ret;
 
     /* check state */
-    if (inflateStateCheck(strm)) return Z_STREAM_ERROR;
+    if (inflateStateCheck(strm) || dictionary == Z_NULL)
+        return Z_STREAM_ERROR;
     state = (struct inflate_state FAR *)strm->state;
     if (state->wrap != 0 && state->mode != DICT)
         return Z_STREAM_ERROR;

--- a/test/infcover.c
+++ b/test/infcover.c
@@ -361,6 +361,9 @@ local void cover_support(void)
     ret = inflatePrime(&strm, -1, 0);           assert(ret == Z_OK);
     ret = inflateSetDictionary(&strm, Z_NULL, 0);
                                                 assert(ret == Z_STREAM_ERROR);
+    ret = inflateReset2(&strm, -15);            assert(ret == Z_OK);
+    ret = inflateSetDictionary(&strm, Z_NULL, 1);
+                                                assert(ret == Z_STREAM_ERROR);
     ret = inflateEnd(&strm);                    assert(ret == Z_OK);
     mem_done(&strm, "prime");
 


### PR DESCRIPTION
## Summary

Reject a null `dictionary` in `inflateSetDictionary()` before raw-inflate dictionary handling reaches `updatewindow()`.

The API documentation already specifies that a null dictionary is an invalid parameter and should return `Z_STREAM_ERROR`. The zlib-wrapper path happens to reject it because the stream is not in `DICT`, but raw inflate permits dictionaries at any time. In that mode, a nonzero `dictLength` with `dictionary == Z_NULL` reaches `updatewindow()` and passes a null source to the window copy, causing a crash.

`deflateSetDictionary()` already validates the same pointer. This change makes the inflate side match the documented contract and adds coverage for the raw-inflate case.

## Validation

- pristine `origin/develop`: `inflateSetDictionary(&strm, Z_NULL, 1)` after `inflateInit2(&strm, -15)` triggers UBSan and then an ASan null-read in `updatewindow()`
- patched focused call: returns `Z_STREAM_ERROR` (`-2`)
- CMake build: pass
- CTest: 15/15 tests pass, including `infcover`
- `git diff --check`: pass
