### PR TITLE
minizip: null-terminate the filename buffer when the stored name is truncated

### DIFF
--- a/contrib/minizip/unzip.c
+++ b/contrib/minizip/unzip.c
@@ -859,8 +859,16 @@ local int unz64local_GetCurrentFileInfoInternal(unzFile file,
             *(szFileName+file_info.size_filename)='\0';
             uSizeRead = file_info.size_filename;
         }
+        else if (fileNameBufferSize>0)
+        {
+            /* stored name doesn't fit: keep one byte back so we can still
+               null-terminate inside the caller's buffer instead of filling
+               it completely and leaving callers to strlen() past the end */
+            uSizeRead = fileNameBufferSize-1;
+            *(szFileName+uSizeRead)='\0';
+        }
         else
-            uSizeRead = fileNameBufferSize;
+            uSizeRead = 0;
 
         if ((file_info.size_filename>0) && (fileNameBufferSize>0))
             if (ZREAD64(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)


### PR DESCRIPTION
There's a stack buffer over-read reachable through `unzGetCurrentFileInfo()` / `unzGetCurrentFileInfo64()` in minizip. When a ZIP entry's stored filename is at least as long as the buffer the caller passed in, `unz64local_GetCurrentFileInfoInternal()` copies exactly `fileNameBufferSize` bytes into it and never writes a terminator, so the buffer comes back completely full with no null anywhere inside it. Whatever the caller does with that buffer next (`strlen`, string comparisons, logging it, `unzLocateFile`, ...) walks off the end.

The fix mirrors what the branch right above it already does when the name does fit: back off by one byte and terminate there. That means a name that's too long for the buffer gets truncated by one extra character compared to before, but it comes back as an actual C string instead of an unterminated 256-byte blob.

I built this with an ASan program that zips up a file with a 264-byte name, reads it back through `unzGetCurrentFileInfo()` into a 256-byte stack buffer, and does `strlen()` on the result. Before the fix that's an immediate stack-buffer-overflow abort; after it, `strlen()` comes back with 255 and nothing complains. Didn't add this as a repo test since minizip doesn't have a unit test harness wired into CMake/CI for this kind of thing, but happy to add one in whatever shape you'd prefer if that's useful.

This affects anything that lets an attacker control ZIP entry names and feeds them to code using minizip with a fixed-size buffer, which is a fairly common pattern (archive tools, upload handlers, etc).
