### PR TITLE
Fix gz_write() crash and data duplication after a stall on a non-blocking destination

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,11 @@
                 ChangeLog file for zlib
 
 Changes in 1.3.2.1 (xx Feb 2026)
-- 
+- Fix gz_write() crash and corruption after a stall on a non-blocking
+  destination: input left pending in the caller's buffer by a partial
+  direct write was assumed to be in the internal input buffer, causing
+  an out-of-bounds copy on the next write, and could be compressed a
+  second time when the caller resubmitted it
 
 Changes in 1.3.2 (17 Feb 2026)
 - Continued rewrite of CMake build [Vollstrecker]

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -201,6 +201,22 @@ local z_size_t gz_write(gz_statep state, voidpc buf, z_size_t len) {
     if (state->skip && gz_zero(state) == -1)
         return 0;
 
+    /* If input is still pending from a previous write that stalled on a
+       non-blocking destination, and that pending input is not in the input
+       buffer, then it is in the caller's buffer, left there by a direct
+       (large) write.  Such input was not counted as consumed when the
+       previous partial result was returned, so the caller will provide it
+       again, starting at the current position of the new call's buffer.
+       Since that pending input has not yet been given to deflate, nothing
+       is lost by dropping the pending reference to it here and letting
+       this call's input be compressed in its place.  (Input pending in
+       the input buffer itself must be kept, as it was already counted as
+       consumed and is not being provided again.) */
+    if (state->strm.avail_in &&
+        (state->strm.next_in < state->in ||
+         state->strm.next_in >= state->in + state->size))
+        state->strm.avail_in = 0;
+
     /* for small len, copy to input buffer, otherwise compress directly */
     if (len < state->size) {
         /* copy to input buffer, compress when full */


### PR DESCRIPTION
## Summary

`gz_write()` crashes (and can corrupt memory) when a write to a **non-blocking** destination stalls and is resumed. Triggered by the documented usage pattern for the `'N'` mode added in 1.3.2: `gzwrite()` returns a partial count on `EAGAIN`, and the caller continues with subsequent `gz*` calls.

## Root cause

When a *large* write takes the direct-compression path in `gz_write()` (`gzwrite.c`, `else` branch), `strm->next_in` is pointed at the **caller's buffer**. If `gz_comp()` stalls with `EAGAIN`, it returns `-1` with `strm->avail_in > 0` and `strm->next_in` still inside the caller's buffer. Those bytes were not counted as consumed (the partial return excludes them), so the caller will resubmit them.

The *small* (`len < state->size`) buffered path assumes any pending input lives in the internal input buffer (`state->in`):

```c
have = (unsigned)((state->strm.next_in + state->strm.avail_in) - state->in);
copy = state->size - have;          /* underflows to ~2^32 */
...
memcpy(state->in + have, buf, copy);  /* wild write (gzwrite.c:217) */
```

Since `next_in` points into the caller's buffer (a completely unrelated address), `have` is a huge bogus offset and the `memcpy` writes to a wild address — deterministic SEGV under ASan and on real builds.

The natural retry loop also silently **duplicates data**: once the destination drains, the next large write first pre-compresses the still-pending bytes (`gzwrite.c`, `if (state->strm.avail_in && gz_comp(...) == -1)`) and then compresses the caller's resubmitted buffer, which starts at exactly those same bytes — encoding them twice.

## Fix

The pending bytes were never given to `deflate()` and were not counted as consumed, so the caller always resubmits them. `gz_write()` now drops that stale pending reference when it is not in the internal input buffer and lets the new buffer be compressed in its place. Input pending in the internal buffer is untouched: it was already counted as consumed and is not resubmitted.

## Verification (ASan + UBSan, clang 14, unmodified 1.3.2-era develop HEAD)

| Test | Before | After |
|---|---|---|
| big `gzwrite` stalls on full socket, then `gzputs` | **SEGV** in `gz_write` gzwrite.c:217 | clean, `gzputs` succeeds |
| natural retry loop (`off += gzwrite(...)`) draining peer | **SEGV** after ~65 KB | completes |
| retry loop, mixed buffered/direct/single-byte writes, 200 KB | **SEGV** | byte-exact round trip |
| `gzflush(Z_FINISH)` retried until `Z_OK`, then `gzclose` | n/a | decompressed output identical to input |
| blocking mode `"w"` and `"wN"` on regular files | works | works, unchanged |

`make test` passes on the patched tree.

## Minimal reproducer

```c
int sv[2]; socketpair(AF_UNIX, SOCK_STREAM, 0, sv);
int snd = 4096; setsockopt(sv[0], SOL_SOCKET, SO_SNDBUF, &snd, sizeof snd);
fcntl(sv[0], F_SETFL, O_NONBLOCK);
unsigned char fill[1<<20]; memset(fill, 0, sizeof fill);
while (write(sv[0], fill, 1<<16) > 0) ;        /* fill the socket */
gzFile gz = gzdopen(sv[0], "wN");
unsigned char data[100000];                     /* e.g. pseudo-random */
int r = gzwrite(gz, data, 100000);              /* returns partial, EAGAIN */
gzputs(gz, "short string");                     /* SEGV in gz_write() */
```
