### PR TITLE
Make deflateBound() account for a preset dictionary set after the call

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,9 @@
                 ChangeLog file for zlib
 
 Changes in 1.3.2.1 (xx Feb 2026)
-- 
+- deflateBound() now includes the preset-dictionary Adler-32 when the stream
+  header has not yet been emitted, so the bound holds when a dictionary is
+  provided after deflateBound() and before the first deflate()
 
 Changes in 1.3.2 (17 Feb 2026)
 - Continued rewrite of CMake build [Vollstrecker]

--- a/deflate.c
+++ b/deflate.c
@@ -885,7 +885,15 @@ z_size_t ZEXPORT deflateBound_z(z_streamp strm, z_size_t sourceLen) {
         wraplen = 0;
         break;
     case 1:                                 /* zlib wrapper */
-        wraplen = 6 + (s->strstart ? 4 : 0);
+        /* A preset dictionary adds four bytes of its Adler-32 right after
+           the two-byte header.  This can happen if a dictionary was already
+           provided (strstart is then non-zero), or if deflateBound() was
+           called before deflateSetDictionary() and the header has not yet
+           been emitted (status is still INIT_STATE, as no data has been
+           compressed).  Include the four bytes in the latter case as well,
+           so the returned bound covers the documented use of allocating an
+           output buffer for a single-pass deflate(). */
+        wraplen = 6 + (s->strstart || s->status == INIT_STATE ? 4 : 0);
         break;
 #ifdef GZIP
     case 2:                                 /* gzip wrapper */


### PR DESCRIPTION
## Summary

`deflateBound()` can return a bound that is **four bytes too small**, breaking the single-pass guarantee documented in zlib.h, when `deflateSetDictionary()` is called *after* `deflateBound()` and before the first `deflate()`.

## The documented contract (zlib.h)

> deflateBound() returns an upper bound on the compressed size after deflation of sourceLen bytes. It must be called after deflateInit() or deflateInit2(), and after deflateSetHeader(), if used. ... If that first deflate() call is provided the sourceLen input bytes, an output buffer allocated to the size returned by deflateBound(), and the flush value Z_FINISH, then deflate() is guaranteed to return Z_STREAM_END.

`deflateSetDictionary()`'s documentation only requires that it be called after `deflateInit()`/`deflateInit2()` and *before* `deflate()` — no ordering relative to `deflateBound()` is stated. So init → bound → setDictionary → single-pass finish is a fully legal sequence.

## Root cause

When a preset dictionary is in use, the emitted zlib header carries the `PRESET_DICT` flag followed by the **four bytes of the dictionary's Adler-32** (deflate.c header emission). `deflateBound_z()` accounts for this only via `wraplen = 6 + (s->strstart ? 4 : 0)`:

- dictionary set *before* `deflateBound()` → `s->strstart` is non-zero → the +4 is included. Correct.
- dictionary set *after* `deflateBound()` (legal per the docs) → at bound time `s->strstart == 0` and the stream has not emitted its header → +4 is **not** included → the bound is short by exactly the four dictionary-Adler bytes that the later header will carry.

## Impact

A caller that allocates exactly `deflateBound()` bytes and relies on the documented one-call `Z_STREAM_END` guarantee gets `Z_OK` with `avail_out == 0` instead — the output buffer fills up four bytes early, and the stream is silently truncated (missing the dictionary Adler-32 and the first bytes of compressed data). Downstream decoders either fail or, for streams where the truncation lands on a block boundary, produce a subtly different stream.

Verified on current develop (e3dc0a85): for incompressible input of 1–100,000 bytes with dictionary lengths 1–30000, **every** case returned `Z_OK` with the buffer full instead of `Z_STREAM_END` (35/35 configurations).

## Fix

Include the four preset-dictionary bytes whenever the header has not yet been emitted — i.e. when no data has been compressed yet and the stream status is still `INIT_STATE` — not only when a dictionary has already been loaded:

```c
wraplen = 6 + (s->strstart || s->status == INIT_STATE ? 4 : 0);
```

Once the header has been emitted (status past `INIT_STATE`), the dictionary Adler-32 is already part of the accounted output, so no double counting occurs. The bound becomes conservative by at most four bytes for streams that never use a preset dictionary.

## Verification

- Reproducer: `deflateInit` → `deflateBound(n)` → `deflateSetDictionary` → one-shot `deflate(Z_FINISH)` with `avail_out = bound`. Before: `Z_OK`, buffer full (35/35 cases). After: `Z_STREAM_END` in all cases.
- `make test` passes on the patched tree.

