### PR TITLE
gzip: initialise state->past for write handles too, not just read handles

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -68,9 +68,9 @@ char ZLIB_INTERNAL *gz_strwinerror(DWORD error) {
 /* Reset gzip file state */
 local void gz_reset(gz_statep state) {
     state->x.have = 0;              /* no output data available */
+    state->past = 0;                /* have not read past end yet */
     if (state->mode == GZ_READ) {   /* for reading ... */
         state->eof = 0;             /* not at end of file */
-        state->past = 0;            /* have not read past end yet */
         state->how = LOOK;          /* look for gzip header */
         state->junk = -1;           /* mark first member */
     }


### PR DESCRIPTION
Fixes #1303.

`gz_reset()` initialises `state->past` only inside the `state->mode == GZ_READ` branch, but `gz_open()` allocates `gz_state` with plain `malloc()` and does not zero it. Since a4e4521, `gzseek64()` and `gztell64()` read `state->past` in either mode, so a write-mode handle reads `past` out of indeterminate heap.

In write mode nothing ever writes to `past`, so the correct value there is always 0 and the fold `offset += past ? 0 : skip` in `gzseek64()` should always happen. When the indeterminate byte comes up non-zero the fold is skipped: two `SEEK_CUR` seeks with no write between them drop the first seek's pending zero-fill, and the resulting gzip stream is well-formed with a valid CRC and the wrong contents. `gztell()` returns the wrong position after a deferred seek for the same reason, breaking the `gztell(file) == gzseek(file, 0L, SEEK_CUR)` equivalence documented in `zlib.h`.

The fix is one line moved: lift `state->past = 0` out of the `GZ_READ` branch so both modes start with it zeroed.

## Verified

`master` at `e3dc0a8`, `-O0 -g -fsanitize=address,undefined` build on Debian.

- A minimal reproducer (`gzopen("wb")` → two `gzseek(5, SEEK_CUR)` calls → `gzwrite("HELLO", 5)` → close → decompress) that expects 15 bytes reproduces the bug five runs out of five under `MALLOC_PERTURB_=170` on the unpatched tree (10 bytes back: five zeros dropped) and passes five out of five with the fix in place (15 bytes back: ten zeros + `HELLO`).
- `make test` prints *** zlib test OK *** and *** zlib 64-bit test OK ***.
- Sanity checks on a normal write with no seek, a single seek + write, and read-past-EOF `gzeof()` all still behave the same.

## Notes

Reported and root-caused by @jxravi.

I used an AI coding assistant while working on this. Every hunk was reviewed by a human before commit, the reproducer and regressions were run on real hardware, and the diff is one line moved with no logic change beyond the reported bug.

Predator CI review	3-model (deepseek-chat CLEAN, glm-4.6 2 issues both FP-verified against gz_open() source, deepseek-r1 CLEAN). No confirmed defects.